### PR TITLE
Add isolate_post_checkout hook to isolate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ with different hooks.
 The following is a list of currently supported hooks (their expected filenames).
 
 - `request_review_post_sync` - hook executed by `request-review` command after succesfully syncing the patch to remote - generally used to create a pull request / patch email & send it
+- `isolate_post_checkout` - hook executed by `isolate` command after successfully creating the temporary branch, cherry-picking the patch to it, and checking the branch out
 
 You can find examples of hooks that you can straight up use or just use as a starting point in [example_hooks](/example_hooks).
 


### PR DESCRIPTION
Add the isolate_post_checkout hook to the isolate command so that after
it has successfully checked out that branch the hook can be used to run
things like build scripts and test suites to make sure that the patch is
actually independent, buildable, and testable.

The approach is basically to try and get hook. If it is found then
execute the hook. If it isn't found then print out a warning on standard
error explaining the siutation and that the hook was skipped.

This relates to issue #50.

[changelog]
added: isolate_post_checkout hook to the isolate command

ps-id: 642db3fc-eaab-4fe8-9433-124354cfc4ae