### PR TITLE
Add: request_review_post_sync example for reopening Github

### DIFF
--- a/example_hooks/request_review_post_sync-github-cli-with-reopen-and-assign-to-self-example
+++ b/example_hooks/request_review_post_sync-github-cli-with-reopen-and-assign-to-self-example
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# request_review_post_sync hook using GitHub CLI (https://cli.github.com)
+#
+# This hook handles requesting review after the sync step of the request review
+# command has completed.
+#
+# In this particular case a pull request will be created within GitHub by using
+# the GitHub CLI. If re-requesting a review the browser will open
+# the associated pull request in the browser.
+# Therefore, you need to make sure that you have the GitHub CLI
+# installed, in your PATH, and have logged into it for this hook to work.
+#
+# Setup:
+# > brew install gh
+# > gh auth login
+
+re_requesting_review=$1 # string of "true" or "false"
+branch_to_integrate=$2 # string of the branch name to integrate (e.g. ps/rr/your-patches-branch-name)
+branch_to_integrate_into=$3 # string of the branch name to integrate into (e.g. main)
+
+# If true then open the PR to view it online else create it
+if [ "$re_requesting_review" == "true" ]; then
+  gh pr view "$branch_to_integrate" --web 
+else
+  # Consider using the reviewer flag on a project level hook if you have teams like @dev ie: --reviewer @dev
+  gh pr create --assignee @me --fill --web --base "$branch_to_integrate_into" --head "$branch_to_integrate"
+fi


### PR DESCRIPTION
[changelog]
added: request_review_post_sync example: Reopen Github if re-requesting. Also assigns yourself to the PR.

ps-id: 53755bfa-3548-4aa0-9772-2a94dbadea7e

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uptech/git-ps-rs/77)
<!-- Reviewable:end -->
