### PR TITLE
Add color & human readable err output to rr cmd

### DIFF
--- a/src/commands/request_review.rs
+++ b/src/commands/request_review.rs
@@ -6,10 +6,18 @@
 // inside of the `ps` module.
 
 use gps as ps;
+use ansi_term::Colour::Red;
 
-pub fn request_review(patch_index: usize, branch_name: Option<String>) {
+pub fn request_review(patch_index: usize, branch_name: Option<String>, color: bool) {
   match ps::request_review(patch_index, branch_name) {
     Ok(_) => {},
-    Err(e) => eprintln!("Error: {:?}", e)
+    Err(e) => {
+      let error_string = format!("\n\n{}\n\n", e);
+      if color {
+        eprintln!("{}", Red.paint(error_string))
+      } else {
+        eprintln!("{}", error_string)
+      }
+    }
   };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ fn main() {
         cli::Command::List => commands::list::list(opt.color),
         cli::Command::Rebase(opts) => commands::rebase::rebase(opts.r#continue),
         cli::Command::Pull => commands::pull::pull(opt.color),
-        cli::Command::RequestReview(opts) => commands::request_review::request_review(opts.patch_index, opts.branch_name),
+        cli::Command::RequestReview(opts) => commands::request_review::request_review(opts.patch_index, opts.branch_name, opt.color),
         cli::Command::Show(opts) => commands::show::show(opts.patch_index),
         cli::Command::Sync(opts) => commands::sync::sync(opts.patch_index, opts.branch_name),
         cli::Command::Isolate(opts) => commands::isolate::isolate(opts.patch_index),


### PR DESCRIPTION
The intention with this change is to make things clearer when the
request review command fails. Prior to this change the output was kinda
just like any other output in the sea of output. Hopefully this change
pulls the error out of the sea a bit by adding the blank lines around it
as well as adding the Red coloring of the error message. I also adding
transaltion from the error types to human readable messages so that
users might better understand what happened.

This is related to issue #80.

[changelog]
added: colored & human redable err output to request review command

ps-id: 59812e17-fd6a-41dc-b364-2332ea3a72e3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uptech/git-ps-rs/81)
<!-- Reviewable:end -->
