### PR TITLE
Add config to pull after integrate

### DIFF
--- a/src/ps/private/config/get_config.rs
+++ b/src/ps/private/config/get_config.rs
@@ -60,6 +60,7 @@ fn apply_pull_config_defaults(pull_config_dto: &PullConfigDto) -> PsPullConfig {
 fn apply_integrate_config_defaults(integrate_config_dto: &IntegrateConfigDto) -> PsIntegrateConfig {
   PsIntegrateConfig {
     prompt_for_reassurance: integrate_config_dto.prompt_for_reassurance.unwrap_or(true),
-    verify_isolation: integrate_config_dto.verify_isolation.unwrap_or(true)
+    verify_isolation: integrate_config_dto.verify_isolation.unwrap_or(true),
+    pull_after_integrate: integrate_config_dto.pull_after_integrate.unwrap_or(false)
   }
 }

--- a/src/ps/private/config/integrate_config_dto.rs
+++ b/src/ps/private/config/integrate_config_dto.rs
@@ -5,7 +5,8 @@ use super::super::utils;
 #[derive(Debug, Deserialize, Clone, Default)]
 pub struct IntegrateConfigDto {
   pub prompt_for_reassurance: Option<bool>,
-  pub verify_isolation: Option<bool>
+  pub verify_isolation: Option<bool>,
+  pub pull_after_integrate: Option<bool>
 }
 
 impl utils::Mergable for IntegrateConfigDto {
@@ -13,7 +14,8 @@ impl utils::Mergable for IntegrateConfigDto {
   fn merge(&self, b: &Self) -> Self {
     IntegrateConfigDto {
       prompt_for_reassurance: b.prompt_for_reassurance.or(self.prompt_for_reassurance),
-      verify_isolation: b.verify_isolation.or(self.verify_isolation)
+      verify_isolation: b.verify_isolation.or(self.verify_isolation),
+      pull_after_integrate: b.pull_after_integrate.or(self.pull_after_integrate),
     }
   }
 }

--- a/src/ps/private/config/ps_config.rs
+++ b/src/ps/private/config/ps_config.rs
@@ -18,5 +18,6 @@ pub struct PsPullConfig {
 #[derive(Debug)]
 pub struct PsIntegrateConfig {
   pub prompt_for_reassurance: bool,
-  pub verify_isolation: bool
+  pub verify_isolation: bool,
+  pub pull_after_integrate: bool
 }


### PR DESCRIPTION
Allow user to specify whether or not they want gps to pull latest after they integrate a patch

This is done to give our users the ability to pull latest after integrating a patch, avoiding having to do it manually because integrating always leaves them in a diverged state.

I added the pull_after_integrate config to the integrate portion of the configs. I defaulted it to `false` to maintain current behavior.

#130 

[changelog]
added: configuration option to pull after integration

ps-id: 37319f25-cb36-44b2-8e57-c51424abef00