### PR TITLE
Add backup-stack command

### DIFF
--- a/doc/gps-backup-stack.1
+++ b/doc/gps-backup-stack.1
@@ -1,0 +1,24 @@
+.TH "GPS\-BACKUP\-STACK" "1" "2022-07-07" "Git Patch Stack Manual"
+
+.SH NAME
+gps-backup-stack \- backup current patch stack
+
+.SH SYNOPSIS
+\fBgps backup-stack\fR
+\fIbranch-name\fR
+
+.SH DESCRIPTION
+This command backs up your current patch stack to a given
+\fIbranch-name\fR. It accomplishes this by force pushing the patch stack
+branch up to the given branch name on the stack's upstream remote.
+
+\fBWarning:\fR This does a force push so it will replace any reference that
+has the same name that you specify on the remote.
+
+.SH OPTIONS
+.TP
+\fIbranch-name\fR
+The branch name to back the patch stack up to.
+
+.SH GIT PATCH STACK
+Part of the gps(1) suite

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -98,6 +98,11 @@ pub struct UnstageCmdOpts {
 }
 
 #[derive(Debug, StructOpt)]
+pub struct BackupStackCmdOpts {
+  pub branch_name: String
+}
+
+#[derive(Debug, StructOpt)]
 pub enum Command {
     /// Your bridge back to the world of normal git and git concepts.
     /// Basically a utility to help you create a normal git branch from a
@@ -243,7 +248,11 @@ remote with newly rebased patch.
     Log,
 
     /// unstage currently staged changes
-    Unstage(UnstageCmdOpts)
+    Unstage(UnstageCmdOpts),
+
+    /// (bs) backup your current patch stack to the given branch name
+    #[structopt(name = "backup-stack", alias = "bs")]
+    BackupStack(BackupStackCmdOpts)
 }
 
 #[derive(Debug, StructOpt)]

--- a/src/commands/backup_stack.rs
+++ b/src/commands/backup_stack.rs
@@ -1,0 +1,9 @@
+use gps as ps;
+use std::string::String;
+
+pub fn backup_stack(branch_name: String) {
+  match ps::backup_stack(branch_name) {
+    Ok(_) => {},
+    Err(e) => eprintln!("Error: {:?}", e)
+  }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -21,3 +21,4 @@ pub mod add_changes_to_stage;
 pub mod log;
 pub mod unstage;
 pub mod utils;
+pub mod backup_stack;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,3 +21,4 @@ pub use ps::public::add_changes_to_stage::add_changes_to_stage;
 pub use ps::public::log::log;
 pub use ps::public::unstage::unstage;
 pub use ps::public::latest_github_release::{notify_of_newer_release, newer_release_available};
+pub use ps::public::backup_stack::backup_stack;

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,7 @@ fn main() {
         cli::Command::Status => commands::status::status(),
         cli::Command::Add(opts) => commands::add_changes_to_stage::add_changes_to_stage(opts.interactive, opts.patch, opts.edit, opts.all, opts.files),
         cli::Command::Log => commands::log::log(),
-        cli::Command::Unstage(opts) => commands::unstage::unstage(opts.files)
+        cli::Command::Unstage(opts) => commands::unstage::unstage(opts.files),
+        cli::Command::BackupStack(opts) => commands::backup_stack::backup_stack(opts.branch_name) 
     };
 }

--- a/src/ps/public/backup_stack.rs
+++ b/src/ps/public/backup_stack.rs
@@ -1,0 +1,26 @@
+use super::super::private::git;
+use std::result::Result;
+
+#[derive(Debug)]
+pub enum BackupStackError {
+  OpenRepositoryFailed(git::CreateCwdRepositoryError),
+  CurrentBranchNameMissing,
+  GetUpstreamBranchNameFailed,
+  GetRemoteNameFailed,
+  ConvertStringToStrFailed,
+  PushFailed(git::ExtForcePushError)
+}
+
+pub fn backup_stack(branch_name: String) -> Result<(), BackupStackError>  {
+  let repo = git::create_cwd_repo().map_err(BackupStackError::OpenRepositoryFailed)?;
+
+  let cur_branch_name = git::get_current_branch(&repo).ok_or(BackupStackError::CurrentBranchNameMissing)?;
+  let branch_upstream_name = git::branch_upstream_name(&repo, cur_branch_name.as_str()).map_err(|_| BackupStackError::GetUpstreamBranchNameFailed)?;
+  let remote_name = repo.branch_remote_name(&branch_upstream_name).map_err(|_| BackupStackError::GetRemoteNameFailed)?;
+  let remote_name_str = remote_name.as_str().ok_or(BackupStackError::ConvertStringToStrFailed)?;
+
+  // e.g. git push <remote> <stack-branch>:<branch-name>
+  git::ext_push(true, remote_name_str, &cur_branch_name, &branch_name).map_err(BackupStackError::PushFailed)?;
+
+  Ok(())
+}

--- a/src/ps/public/mod.rs
+++ b/src/ps/public/mod.rs
@@ -16,3 +16,4 @@ pub mod add_changes_to_stage;
 pub mod log;
 pub mod unstage;
 pub mod latest_github_release;
+pub mod backup_stack;


### PR DESCRIPTION
Add backup-stack command so that users can easily backup their current
patch stack.

ps-id: 8dba630d-6f5d-4ea9-80cb-45d597f4bcb0