### PR TITLE
Update verification prompt for integration

### DIFF
--- a/src/ps/public/integrate.rs
+++ b/src/ps/public/integrate.rs
@@ -218,7 +218,7 @@ pub enum GetVerificationError {
 
 fn get_verification() -> Result<(), GetVerificationError> {
   let mut answer = String::new();
-  println!("\n\nAre you sure you want to integrate this patch? (Yes/No)");
+  println!("\n\nAre you sure you want to integrate this patch? (y/N)");
   std::io::stdin().read_line(&mut answer).map_err(GetVerificationError::ReadLineFailed)?;
   let normalized_answer = answer.to_lowercase().trim().to_string();
   if normalized_answer == "yes" || normalized_answer == "y" {


### PR DESCRIPTION
This simply updates the string prompt for the verification confirmation with `y/N` instead of `Yes/No`. This is to let users know that they may use abbreviations and that "no" is the default.

[changelog]
changed: updated integration confirmation prompt to reflect the shortened answer

ps-id: 63140387-d60e-4ff2-8eaf-03062099d961