### PR TITLE
Add execute with output function

### DIFF
--- a/src/ps/private/utils/execute.rs
+++ b/src/ps/private/utils/execute.rs
@@ -1,5 +1,5 @@
 use std::os::unix::prelude::ExitStatusExt;
-use std::process::Command;
+use std::process::{Command, Output};
 use std::io;
 use std::result::Result;
 
@@ -35,4 +35,13 @@ pub fn execute(exe: &str, args: &[&str]) -> Result<(), ExecuteError> {
       }
     }
   }
+}
+
+#[derive(Debug)]
+pub enum ExecuteWithOutputError {
+  Failure(io::Error)
+}
+
+pub fn execute_with_output(exe: &str, args: &[&str]) -> Result<Output, ExecuteWithOutputError> {
+  Command::new(exe).args(args).output().map_err(ExecuteWithOutputError::Failure)
 }


### PR DESCRIPTION
Add a function to execute a script and return it's output, so we can use it with the list_additional_info hook.

I added a util function in a separate file to the `execute` function, so we have one function per file. The function accepts a file name to execute and returns the output on success.

Relates to uptech/git-ps-rs#123

ps-id: d851dd86-a362-4d44-a81a-783f071b3f6a