### PR TITLE
Add util to trim trailing new line

### DIFF
--- a/src/ps/private/utils/mod.rs
+++ b/src/ps/private/utils/mod.rs
@@ -1,6 +1,7 @@
 mod execute;
 mod mergable;
 mod print_warn;
+mod string_manipulation;
 
 pub use execute::{execute, ExecuteError};
 pub use mergable::Mergable;

--- a/src/ps/private/utils/string_manipulation.rs
+++ b/src/ps/private/utils/string_manipulation.rs
@@ -1,0 +1,16 @@
+pub fn strip_newlines(s: &str) -> String {
+  return s.replace('\n', "").replace('\r', "");
+}
+
+#[cfg(test)]
+mod tests {
+  #[test]
+  fn test_trim_newlines() {
+    let text = "hel
+l
+
+o
+";
+    assert_eq!(super::strip_newlines(text), "hello");
+  }
+}


### PR DESCRIPTION
Add util to trim new lines in string
    
Add a utility function to take a string and trim a new lines in it, if it has any. This will be used to format the output of the list_additional_info hook, since a new lines would break the layout of the whole list.
    
I created a function that borrows a string slice and returns a string without new line characters. I also import the module in mod.rs so that the test is picked up.
    
Relates to uptech/git-ps-rs#123
    
ps-id: d73136f2-080b-4fde-9d37-940dfbd153d5