### PR TITLE
Add util to set a string's width

### DIFF
--- a/src/ps/private/utils/string_manipulation.rs
+++ b/src/ps/private/utils/string_manipulation.rs
@@ -2,6 +2,11 @@ pub fn strip_newlines(s: &str) -> String {
   return s.replace('\n', "").replace('\r', "");
 }
 
+pub fn set_string_width(s: &str, width: usize) -> String {
+  let trimmed_str = format!("{:.len$}", s, len = width);
+  return format!("{:<len$}", trimmed_str, len = width);
+}
+
 #[cfg(test)]
 mod tests {
   #[test]
@@ -12,5 +17,17 @@ l
 o
 ";
     assert_eq!(super::strip_newlines(text), "hello");
+  }
+
+  #[test]
+  fn test_set_string_width_longer() {
+    let text = "hello";
+    assert_eq!(super::set_string_width(text, 10), "hello     ")
+  }
+
+  #[test]
+  fn test_set_string_width_shorter() {
+    let text = "hello";
+    assert_eq!(super::set_string_width(text, 3), "hel")
   }
 }


### PR DESCRIPTION
Add a utility function that takes a string and returns a string of a fixed width. This will be used in the list output to ensure all the lines have the same width of additional info output, otherwise it'll look weird.

Relates to uptech/git-ps-rs#123

ps-id: 97c122b2-bb99-437e-99e6-0f660a714c32