### PR TITLE
Add list dto to config dto

### DIFF
--- a/src/ps/private/config/config_dto.rs
+++ b/src/ps/private/config/config_dto.rs
@@ -2,6 +2,7 @@ use super::request_review_config_dto::*;
 use super::pull_config_dto::*;
 use super::integrate_config_dto::*;
 use super::fetch_config_dto::*;
+use super::list_config_dto::*;
 use serde::Deserialize;
 use super::super::utils;
 
@@ -10,7 +11,8 @@ pub struct ConfigDto {
   pub request_review: Option<RequestReviewConfigDto>,
   pub pull: Option<PullConfigDto>,
   pub integrate: Option<IntegrateConfigDto>,
-  pub fetch: Option<FetchConfigDto>
+  pub fetch: Option<FetchConfigDto>,
+  pub list: Option<ListConfigDto>
 }
 
 impl utils::Mergable for ConfigDto {
@@ -19,7 +21,8 @@ impl utils::Mergable for ConfigDto {
       request_review: b.request_review.as_ref().map(|b_rr| self.request_review.as_ref().map(|a_rr| a_rr.merge(b_rr)).unwrap_or_else(|| (*b_rr).clone())).or_else(|| self.request_review.clone()),
       pull: b.pull.as_ref().map(|b_pull| self.pull.as_ref().map(|a_pull| a_pull.merge(b_pull)).unwrap_or_else(|| (*b_pull).clone())).or_else(|| self.pull.clone()),
       integrate: b.integrate.as_ref().map(|b_int| self.integrate.as_ref().map(|a_int| a_int.merge(b_int)).unwrap_or_else(|| (*b_int).clone())).or_else(|| self.integrate.clone()),
-      fetch: b.fetch.as_ref().map(|b_fetch| self.fetch.as_ref().map(|a_fetch| a_fetch.merge(b_fetch)).unwrap_or_else(|| (*b_fetch).clone())).or_else(|| self.fetch.clone())
+      fetch: b.fetch.as_ref().map(|b_fetch| self.fetch.as_ref().map(|a_fetch| a_fetch.merge(b_fetch)).unwrap_or_else(|| (*b_fetch).clone())).or_else(|| self.fetch.clone()),
+      list: b.list.as_ref().map(|b_list| self.list.as_ref().map(|a_list| a_list.merge(b_list)).unwrap_or_else(|| (*b_list).clone())).or_else(|| self.list.clone()),
     }
   }
 }

--- a/src/ps/private/config/mod.rs
+++ b/src/ps/private/config/mod.rs
@@ -2,6 +2,7 @@ mod request_review_config_dto;
 mod pull_config_dto;
 mod integrate_config_dto;
 mod fetch_config_dto;
+mod list_config_dto;
 mod config_dto;
 mod read_config;
 mod read_config_or_default;


### PR DESCRIPTION
Add the list dto to the config dto so we can use it safely when running the list command and getting the additional info hook.

Relates to #123

ps-id: 941ad3df-1b5c-40f0-a702-38dc5c211786