### PR TITLE
Add list configs defaults

### DIFF
--- a/src/ps/private/config/get_config.rs
+++ b/src/ps/private/config/get_config.rs
@@ -5,7 +5,8 @@ use super::pull_config_dto::PullConfigDto;
 use super::request_review_config_dto::RequestReviewConfigDto;
 use super::integrate_config_dto::IntegrateConfigDto;
 use super::fetch_config_dto::FetchConfigDto;
-use super::ps_config::{PsConfig, PsPullConfig, PsRequestReviewConfig, PsIntegrateConfig, PsFetchConfig};
+use super::list_config_dto::ListConfigDto;
+use super::ps_config::{PsConfig, PsPullConfig, PsRequestReviewConfig, PsIntegrateConfig, PsFetchConfig, PsListConfig};
 use super::super::utils::*;
 
 #[derive(Debug)]
@@ -40,11 +41,13 @@ fn apply_config_defaults(config_dto: &ConfigDto) -> PsConfig {
   let default_pull_config = apply_pull_config_defaults(&PullConfigDto::default());
   let default_integrate_config = apply_integrate_config_defaults(&IntegrateConfigDto::default());
   let default_fetch_config = apply_fetch_config_defaults(&FetchConfigDto::default());
+  let default_list_config = apply_list_config_defaults(&ListConfigDto::default());
   PsConfig {
     request_review: config_dto.request_review.as_ref().map(apply_request_review_config_defaults).unwrap_or(default_rr_config),
     pull: config_dto.pull.as_ref().map(apply_pull_config_defaults).unwrap_or(default_pull_config),
     integrate: config_dto.integrate.as_ref().map(apply_integrate_config_defaults).unwrap_or(default_integrate_config),
-    fetch: config_dto.fetch.as_ref().map(apply_fetch_config_defaults).unwrap_or(default_fetch_config)
+    fetch: config_dto.fetch.as_ref().map(apply_fetch_config_defaults).unwrap_or(default_fetch_config),
+    list: config_dto.list.as_ref().map(apply_list_config_defaults).unwrap_or(default_list_config)
   }
 }
 
@@ -71,5 +74,12 @@ fn apply_integrate_config_defaults(integrate_config_dto: &IntegrateConfigDto) ->
 fn apply_fetch_config_defaults(fetch_config_dto: &FetchConfigDto) -> PsFetchConfig {
   PsFetchConfig {
     show_upstream_patches_after_fetch: fetch_config_dto.show_upstream_patches_after_fetch.unwrap_or(true)
+  }
+}
+
+fn apply_list_config_defaults(list_config_dto: &ListConfigDto) -> PsListConfig {
+  PsListConfig {
+    add_extra_patch_info: list_config_dto.add_extra_patch_info.unwrap_or(false),
+    extra_patch_info_length: list_config_dto.extra_patch_info_length.unwrap_or(10),
   }
 }

--- a/src/ps/private/config/ps_config.rs
+++ b/src/ps/private/config/ps_config.rs
@@ -3,7 +3,8 @@ pub struct PsConfig {
   pub request_review: PsRequestReviewConfig,
   pub pull: PsPullConfig,
   pub integrate: PsIntegrateConfig,
-  pub fetch: PsFetchConfig
+  pub fetch: PsFetchConfig,
+  pub list: PsListConfig
 }
 
 #[derive(Debug)]
@@ -26,4 +27,10 @@ pub struct PsIntegrateConfig {
 #[derive(Debug)]
 pub struct PsFetchConfig {
   pub show_upstream_patches_after_fetch: bool
+}
+
+#[derive(Debug)]
+pub struct PsListConfig {
+  pub add_extra_patch_info: bool,
+  pub extra_patch_info_length: usize
 }


### PR DESCRIPTION
Add default values for the list configs and apply them when getting the configs through the `get_config` method. Also added struct for the list configs so we can use it in the get_config method

Relates to #123

ps-id: ec1f693e-82ff-404e-b791-cada8748b455