### PR TITLE
Get additional information from hook output

### DIFF
--- a/src/ps/private/list.rs
+++ b/src/ps/private/list.rs
@@ -1,0 +1,22 @@
+use super::{utils, config, paths, hooks::{get_hook_output, HookOutputError}};
+
+#[derive(Debug)]
+pub enum GetAdditionalInfoHookOutputError {
+  GetRepoRootPathFailed(paths::PathsError),
+  PathNotUtf8,
+  GetConfigFailed(config::GetConfigError),
+  GetHookOutputError(HookOutputError),
+}
+
+pub fn get_additional_info_hook_output(repo: &git2::Repository, patch_args: &[&str]) -> Result<String, GetAdditionalInfoHookOutputError> {
+  let repo_root_path = paths::repo_root_path(&repo).map_err(GetAdditionalInfoHookOutputError::GetRepoRootPathFailed)?;
+  let repo_root_str = repo_root_path.to_str().ok_or(GetAdditionalInfoHookOutputError::PathNotUtf8)?;
+  let config = config::get_config(repo_root_str).map_err(GetAdditionalInfoHookOutputError::GetConfigFailed)?;
+
+  let hook_stdout_str_result = get_hook_output(repo, "list_additional_information", patch_args);
+
+  let hook_stdout_str = hook_stdout_str_result.map_err(GetAdditionalInfoHookOutputError::GetHookOutputError)?;
+
+  let hook_stdout_len = config.list.extra_patch_info_length;
+  return Ok(utils::set_string_width(&utils::strip_newlines(&hook_stdout_str), hook_stdout_len));
+}

--- a/src/ps/private/utils/mod.rs
+++ b/src/ps/private/utils/mod.rs
@@ -7,3 +7,4 @@ pub use execute::{execute, execute_with_output, ExecuteError, ExecuteWithOutputE
 pub use mergable::Mergable;
 pub use mergable::merge_option;
 pub use print_warn::print_warn;
+pub use string_manipulation::{strip_newlines, set_string_width};


### PR DESCRIPTION
Add a function that executes the list_additional_information hook and returns the formatted output of it.

I added a function in the private folder that calls `execute_with_output` on the hook and returns a string that is 10 characters long without a trailing new line, which would break the output.

Relates to uptech/git-ps-rs#123

ps-id: 66cbc199-1918-4733-83e2-dbd6291d7d7c