### PR TITLE
Add method to get hook output

### DIFF
--- a/src/ps/private/utils/mod.rs
+++ b/src/ps/private/utils/mod.rs
@@ -3,7 +3,7 @@ mod mergable;
 mod print_warn;
 mod string_manipulation;
 
-pub use execute::{execute, ExecuteError};
+pub use execute::{execute, execute_with_output, ExecuteError, ExecuteWithOutputError};
 pub use mergable::Mergable;
 pub use mergable::merge_option;
 pub use print_warn::print_warn;


### PR DESCRIPTION
Add a private hooks method to execute a hook and get its output. This can be used by any hook, and will be used by the list additional info hook.

Relates to uptech/git-ps-rs#123

ps-id: 9887904b-ee8e-4229-a0a7-ef02725fe0fd