### PR TITLE
Add list cell struct

### DIFF
--- a/src/ps/private/list.rs
+++ b/src/ps/private/list.rs
@@ -1,0 +1,53 @@
+use std::fmt;
+use ansi_term::ANSIGenericString;
+
+use super::utils;
+
+struct ListCell {
+  width: Option<usize>,
+  color: Option<ansi_term::Colour>,
+  value: String,
+}
+
+impl ListCell {
+  fn get_str_fixed_width(&self, str: String) -> String {
+    return self.width.map(|w| utils::set_string_width(&str, w)).unwrap_or(str);
+  }
+
+  fn get_colored_text<'a>(&'a self, str: &'a str) -> ANSIGenericString<str> {
+    return self.color.map(|c| c.paint(str)).unwrap_or(ANSIGenericString::from(str));
+  }
+}
+
+impl fmt::Display for ListCell {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    let without_newlines = utils::strip_newlines(&self.value);
+    let str_fixed_width = self.get_str_fixed_width(without_newlines);
+    let colored_text = self.get_colored_text(&str_fixed_width);
+    return write!(f, "{}", colored_text);
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::ps::private::list::ListCell;
+  use ansi_term::Colour::Blue;
+
+  #[test]
+  fn test_list_cell_fmt_shorter_blue() {
+    let cell = ListCell { width: Some(4), color: Some(Blue), value: "hello".to_string() };
+    assert_eq!(format!("{}", cell), "\u{1b}[34mhell\u{1b}[0m");
+  }
+
+  #[test]
+  fn test_list_cell_fmt_longer_no_color() {
+    let cell = ListCell { width: Some(6), color: None, value: "hello".to_string() };
+    assert_eq!(format!("{}", cell), "hello ");
+  }
+
+  #[test]
+  fn test_list_cell_fmt_no_width_or_color() {
+    let cell = ListCell { width: None, color: None, value: "hello".to_string() };
+    assert_eq!(format!("{}", cell), "hello");
+  }
+}

--- a/src/ps/private/mod.rs
+++ b/src/ps/private/mod.rs
@@ -10,3 +10,4 @@ pub mod config;
 pub mod verify_isolation;
 pub mod commit_is_behind;
 pub mod patch_status;
+pub mod list;

--- a/src/ps/private/utils/mod.rs
+++ b/src/ps/private/utils/mod.rs
@@ -7,3 +7,4 @@ pub use execute::{execute, execute_with_output, ExecuteError, ExecuteWithOutputE
 pub use mergable::Mergable;
 pub use mergable::merge_option;
 pub use print_warn::print_warn;
+pub use string_manipulation::{set_string_width, strip_newlines};


### PR DESCRIPTION
Add a struct for a cell in the list output, so we can organize the list method in a more modular way. This will be followed by a list row struct.

Relates to #123

ps-id: 371dd7cb-b4bd-49b9-b9f5-bd743575dfe9