### PR TITLE
Add list row struct

### DIFF
--- a/src/ps/private/list.rs
+++ b/src/ps/private/list.rs
@@ -3,6 +3,7 @@ use ansi_term::ANSIGenericString;
 
 use super::utils;
 
+#[derive(Debug, PartialEq)]
 struct ListCell {
   width: Option<usize>,
   color: Option<ansi_term::Colour>,
@@ -28,9 +29,39 @@ impl fmt::Display for ListCell {
   }
 }
 
+#[derive(Debug, PartialEq)]
+pub struct ListRow {
+  cells: Vec<ListCell>,
+  with_color: bool,
+}
+
+impl ListRow {
+  pub fn new(with_color: bool) -> Self {
+    Self { with_color, cells: vec![] }
+  }
+
+  pub fn add_cell(&mut self, width: Option<usize>, text_color: Option<ansi_term::Colour>, value: impl fmt::Display) {
+    let color = if self.with_color {text_color} else {None};
+    let cell = ListCell { width, color, value: value.to_string() };
+    self.cells.push(cell)
+  }
+}
+
+impl fmt::Display for ListRow {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    let mut row_str = String::new();
+    
+    for column in &self.cells {
+      row_str.push_str(&column.to_string());
+      row_str.push_str(" ");
+    }
+    write!(f, "{}", row_str)
+  }
+}
+
 #[cfg(test)]
 mod tests {
-  use crate::ps::private::list::ListCell;
+  use crate::ps::private::list::{ListCell, ListRow};
   use ansi_term::Colour::Blue;
 
   #[test]
@@ -49,5 +80,39 @@ mod tests {
   fn test_list_cell_fmt_no_width_or_color() {
     let cell = ListCell { width: None, color: None, value: "hello".to_string() };
     assert_eq!(format!("{}", cell), "hello");
+  }
+
+  #[test]
+  fn test_list_row_new() {
+    let row = ListRow::new(true);
+    assert_eq!(row, ListRow {with_color: true, cells: vec![]});
+  }
+
+  #[test]
+  fn test_list_row_add_cell() {
+    let mut row = ListRow::new(false);
+    let cell_value = "hello".to_string();
+    row.add_cell(None, None, &cell_value);
+    assert_eq!(row, ListRow {with_color: false, cells: vec![ListCell { width: None, color: None, value: cell_value }]});
+  }
+
+  #[test]
+  fn test_list_row_fmt_with_color() {
+    let mut row = ListRow::new(true);
+    let first_cell = ListCell { width: Some(10), color: Some(Blue), value: "Hello".to_string() };
+    let second_cell = ListCell { width: None, color: None, value: "World".to_string() };
+    row.add_cell(first_cell.width, first_cell.color, first_cell.value);
+    row.add_cell(second_cell.width, second_cell.color, second_cell.value);
+    assert_eq!(format!("{}", row), "\u{1b}[34mHello     \u{1b}[0m World ")
+  }
+
+  #[test]
+  fn test_list_row_fmt_without_color() {
+    let mut row = ListRow::new(false);
+    let first_cell = ListCell { width: Some(10), color: Some(Blue), value: "Hello".to_string() };
+    let second_cell = ListCell { width: None, color: None, value: "World".to_string() };
+    row.add_cell(first_cell.width, first_cell.color, first_cell.value);
+    row.add_cell(second_cell.width, second_cell.color, second_cell.value);
+    assert_eq!(format!("{}", row), "Hello      World ")
   }
 }


### PR DESCRIPTION
Add a struct to represent a row in the output of the list command. This will allow us to make the list method more readable and extendable.

Relates to #123

ps-id: 3c6a5c4d-1cba-4a0a-8826-f14ad0e6f97e