### PR TITLE
Refactor list to use list row struct

### DIFF
--- a/src/ps/public/list.rs
+++ b/src/ps/public/list.rs
@@ -1,3 +1,5 @@
+use crate::ps::private::list;
+
 use super::super::private::git;
 use super::super::super::ps;
 use uuid::Uuid;
@@ -41,6 +43,7 @@ pub fn list(color: bool) -> Result<(), ListError> {
     let patch_stack_base_oid = patch_stack.base.target().ok_or(ListError::GetPatchStackBaseTargetFailed)?;
 
     for patch in list_of_patches.into_iter().rev() {
+        let mut row = list::ListRow::new(color);
         let commit = repo.find_commit(patch.oid).map_err(|_| ListError::CommitMissing)?;
         let patch_state = match ps::commit_ps_id(&commit) {
           Some(ps_id) => patch_meta_data.get(&ps_id),
@@ -50,16 +53,13 @@ pub fn list(color: bool) -> Result<(), ListError> {
         let commit_diff_patch_id = git::commit_diff_patch_id(&repo, &commit).map_err(ListError::GetCommitDiffPatchIdFailed)?;
         let patch_status = patch_status::patch_status(patch_state, &repo, commit_diff_patch_id, patch_stack_base_oid).map_err(ListError::PatchStatusFailed)?;
         let patch_status_string = patch_status_to_string(patch_status);
-
-        let patch_str = format!("{:<4}", patch.index);
-        let patch_status_str = format!("{:<6}", patch_status_string);
-        let patch_oid_str = format!("{:.6}", patch.oid);
-
-        if color {
-          println!("{:<4} {:<6} {:.6} {}", Green.paint(patch_str), Cyan.paint(patch_status_str), Yellow.paint(patch_oid_str), patch.summary);
-        } else {
-          println!("{:<4} {:<6} {:.6} {}", patch_str, patch_status_str, patch_oid_str, patch.summary);
-        }
+        
+        row.add_cell(Some(4), Some(Green), patch.index);
+        row.add_cell(Some(6), Some(Cyan), patch_status_string);
+        row.add_cell(Some(6), Some(Yellow), patch.oid);
+        row.add_cell(None, None, patch.summary);
+        
+        println!("{}", row)
     }
 
     Ok(())


### PR DESCRIPTION
Use the list row struct to construct rows of cells for the output of the list command. This allows us to add or edit the output in a more manageable way and makes the method more readable.

Relates to #123

ps-id: 387d9461-a393-40bf-a96b-de30f42cdd8e