### PR TITLE
feature: gps ls can be configured to reverse order

### DIFF
--- a/src/ps/private/config/get_config.rs
+++ b/src/ps/private/config/get_config.rs
@@ -81,5 +81,6 @@ fn apply_list_config_defaults(list_config_dto: &ListConfigDto) -> PsListConfig {
   PsListConfig {
     add_extra_patch_info: list_config_dto.add_extra_patch_info.unwrap_or(false),
     extra_patch_info_length: list_config_dto.extra_patch_info_length.unwrap_or(10),
+    reverse_order: list_config_dto.reverse_order.unwrap_or(false)
   }
 }

--- a/src/ps/private/config/list_config_dto.rs
+++ b/src/ps/private/config/list_config_dto.rs
@@ -5,7 +5,8 @@ use super::super::utils;
 #[derive(Debug, Deserialize, Clone, Default)]
 pub struct ListConfigDto {
   pub add_extra_patch_info: Option<bool>,
-  pub extra_patch_info_length: Option<usize>
+  pub extra_patch_info_length: Option<usize>,
+  pub reverse_order: Option<bool>
 }
 
 impl utils::Mergable for ListConfigDto {
@@ -14,6 +15,7 @@ impl utils::Mergable for ListConfigDto {
     ListConfigDto {
       add_extra_patch_info: b.add_extra_patch_info.or(self.add_extra_patch_info),
       extra_patch_info_length: b.extra_patch_info_length.or(self.extra_patch_info_length),
+      reverse_order: b.reverse_order.or(self.reverse_order)
     }
   }
 }

--- a/src/ps/private/config/ps_config.rs
+++ b/src/ps/private/config/ps_config.rs
@@ -32,5 +32,6 @@ pub struct PsFetchConfig {
 #[derive(Debug)]
 pub struct PsListConfig {
   pub add_extra_patch_info: bool,
-  pub extra_patch_info_length: usize
+  pub extra_patch_info_length: usize,
+  pub reverse_order: bool
 }

--- a/src/ps/public/list.rs
+++ b/src/ps/public/list.rs
@@ -8,6 +8,7 @@ use super::super::private::state_management;
 use super::super::private::paths;
 use ansi_term::Colour::{Green, Yellow, Cyan};
 use super::super::private::patch_status;
+use super::super::private::config;
 
 #[derive(Serialize, Deserialize, Debug)]
 struct RequestReviewRecord {
@@ -28,11 +29,18 @@ pub enum ListError {
   CommitMissing,
   GetCommitDiffPatchIdFailed(git::CommitDiffPatchIdError),
   PatchStatusFailed(patch_status::PatchStatusError),
-  GetPatchStackBaseTargetFailed
+  GetPatchStackBaseTargetFailed,
+  GetRepoRootPathFailed(paths::PathsError),
+  PathNotUtf8,
+  GetConfigFailed(config::GetConfigError),
 }
 
 pub fn list(color: bool) -> Result<(), ListError> {
     let repo = git::create_cwd_repo().map_err(|_| ListError::RepositoryNotFound)?;
+
+    let repo_root_path = paths::repo_root_path(&repo).map_err(ListError::GetRepoRootPathFailed)?;
+    let repo_root_str = repo_root_path.to_str().ok_or(ListError::PathNotUtf8)?;
+    let config = config::get_config(repo_root_str).map_err(ListError::GetConfigFailed)?;
 
     let patch_stack = ps::get_patch_stack(&repo).map_err(ListError::GetPatchStackFailed)?;
     let list_of_patches = ps::get_patch_list(&repo, &patch_stack).map_err(ListError::GetPatchListFailed)?;
@@ -42,7 +50,13 @@ pub fn list(color: bool) -> Result<(), ListError> {
 
     let patch_stack_base_oid = patch_stack.base.target().ok_or(ListError::GetPatchStackBaseTargetFailed)?;
 
-    for patch in list_of_patches.into_iter().rev() {
+    let list_of_patches_iter: Box<dyn Iterator<Item=_>> = if config.list.reverse_order {
+      Box::new(list_of_patches.into_iter())
+    } else {
+      Box::new(list_of_patches.into_iter().rev())
+    };
+
+    for patch in list_of_patches_iter {
         let mut row = list::ListRow::new(color);
         let commit = repo.find_commit(patch.oid).map_err(|_| ListError::CommitMissing)?;
         let patch_state = match ps::commit_ps_id(&commit) {


### PR DESCRIPTION
By adding

```
[list]
reverse_order = true
```

to config.toml, the order of the list of patches given by `gps list`
can be reversed.

I've tested it on my machine and it works.

closes #174 