### PR TITLE
feature: gps a accepts --no-edit

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -92,6 +92,13 @@ pub struct RebaseCmdOpts {
 }
 
 #[derive(Debug, StructOpt)]
+pub struct AmendPatchOpts {
+  /// pass `--no-edit` to git commit
+  #[structopt(long = "no-edit")]
+  pub no_edit: bool
+}
+
+#[derive(Debug, StructOpt)]
 pub struct UnstageCmdOpts {
   /// specific files to unstage changes for, leave blank for all staged files
   pub files: Vec<String>
@@ -235,7 +242,7 @@ remote with newly rebased patch.
     CreatePatch,
     /// (a) - amend the top most patch with the currently staged changes
     #[structopt(name = "amend-patch", alias = "a")]
-    AmendPatch,
+    AmendPatch(AmendPatchOpts),
 
     /// (s) - get the status of local changes & staged changes
     #[structopt(name = "status", alias = "s")]

--- a/src/commands/amend_patch.rs
+++ b/src/commands/amend_patch.rs
@@ -1,7 +1,7 @@
 use gps as ps;
 
-pub fn amend_patch() {
-  match ps::amend_patch() {
+pub fn amend_patch(no_edit: bool) {
+  match ps::amend_patch(no_edit) {
     Ok(_) => {},
     Err(e) => eprintln!("Error: {:?}", e)
   }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ fn main() {
         cli::Command::Isolate(opts) => commands::isolate::isolate(opts.patch_index, opt.color),
         cli::Command::Checkout(opts) => commands::checkout::checkout(opts.patch_index),
         cli::Command::CreatePatch => commands::create_patch::create_patch(),
-        cli::Command::AmendPatch => commands::amend_patch::amend_patch(),
+        cli::Command::AmendPatch(opts) => commands::amend_patch::amend_patch(opts.no_edit),
         cli::Command::Status => commands::status::status(),
         cli::Command::Add(opts) => commands::add_changes_to_stage::add_changes_to_stage(opts.interactive, opts.patch, opts.edit, opts.all, opts.files),
         cli::Command::Log => commands::log::log(),

--- a/src/ps/public/amend_patch.rs
+++ b/src/ps/public/amend_patch.rs
@@ -6,7 +6,12 @@ pub enum AmendPatchError {
   CommitFailed(utils::ExecuteError)
 }
 
-pub fn amend_patch() -> Result<(), AmendPatchError>  {
-  utils::execute("git", &["commit", "-v", "--amend"]).map_err(AmendPatchError::CommitFailed)?;
+pub fn amend_patch(no_edit: bool) -> Result<(), AmendPatchError>  {
+  let args = if no_edit {
+    vec!["commit", "--amend", "--no-edit"]
+  } else {
+    vec!["commit", "--amend"]
+  };
+  utils::execute("git", &args).map_err(AmendPatchError::CommitFailed)?;
   Ok(())
 }


### PR DESCRIPTION
I wonder if we should allow for `gps a n` for the lazy?

Closes #146

Signed-off-by: Ali Caglayan <alizter@gmail.com>
