### PR TITLE
feature: gps batch-request-review

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,6 +9,11 @@ pub struct RequestReview {
 }
 
 #[derive(Debug, StructOpt)]
+pub struct BatchRequestReview {
+  pub patch_index:  Vec<usize>
+}
+
+#[derive(Debug, StructOpt)]
 pub struct BranchCmdOpts {
   /// index of patch to cherry-pick to branch or starting index of patch
   /// series to cherry-pick to the branch
@@ -203,6 +208,9 @@ remote with newly rebased patch.
     /// (rr) - Request review of the specified patch
     #[structopt(name = "request-review", alias = "rr")]
     RequestReview(RequestReview),
+    /// (brr) - Request review of a batch of patches
+    #[structopt(name = "batch-request-review", alias = "brr")]
+    BatchRequestReview(BatchRequestReview),
     /// Show the identified patch in raw form
     #[structopt(name = "show")]
     Show(ShowCmdOpts),

--- a/src/commands/batch_request_review.rs
+++ b/src/commands/batch_request_review.rs
@@ -1,0 +1,8 @@
+use gps as ps;
+
+pub fn batch_request_review(patch_indexes: Vec<usize>, color: bool) {
+  match ps::batch_request_review(patch_indexes, color) {
+    Ok(_) => {},
+    Err(e) => eprintln!("Error: {:?}", e)
+  };
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod list;
 pub mod pull;
 pub mod rebase;
 pub mod request_review;
+pub mod batch_request_review;
 pub mod show;
 pub mod sync;
 pub mod create_patch;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub use ps::public::branch::branch;
 pub use ps::public::list::list;
 pub use ps::public::rebase::rebase;
 pub use ps::public::request_review::{request_review, RequestReviewError};
+pub use ps::public::batch_request_review::{batch_request_review, BatchRequestReviewError};
 pub use ps::public::show::show;
 pub use ps::public::integrate;
 pub use ps::public::checkout::checkout;

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ fn main() {
         cli::Command::Rebase(opts) => commands::rebase::rebase(opts.r#continue),
         cli::Command::Pull => commands::pull::pull(opt.color),
         cli::Command::RequestReview(opts) => commands::request_review::request_review(opts.patch_index, opts.branch_name, opt.color),
+        cli::Command::BatchRequestReview(opts) => commands::batch_request_review::batch_request_review(opts.patch_index, opt.color),
         cli::Command::Show(opts) => commands::show::show(opts.patch_index),
         cli::Command::Sync(opts) => commands::sync::sync(opts.patch_index, opts.branch_name),
         cli::Command::Isolate(opts) => commands::isolate::isolate(opts.patch_index, opt.color),

--- a/src/ps/public/batch_request_review.rs
+++ b/src/ps/public/batch_request_review.rs
@@ -1,0 +1,24 @@
+use super::request_review;
+use std::result::Result;
+
+#[derive(Debug)]
+pub enum BatchRequestReviewError {
+    RequestReviewErrors(Vec<request_review::RequestReviewError>),
+}
+
+pub fn batch_request_review(
+    patch_indexes: Vec<usize>,
+    color: bool,
+) -> Result<(), BatchRequestReviewError> {
+    let mut errors: Vec<request_review::RequestReviewError> = Vec::new();
+    for patch_index in patch_indexes {
+        match request_review::request_review(patch_index, None, color) {
+            Ok(_) => {}
+            Err(e) => errors.push(e),
+        };
+    }
+    match errors.len() {
+        0 => Ok(()),
+        _ => Err(BatchRequestReviewError::RequestReviewErrors(errors)),
+    }
+}

--- a/src/ps/public/mod.rs
+++ b/src/ps/public/mod.rs
@@ -7,6 +7,7 @@ pub mod list;
 pub mod pull;
 pub mod rebase;
 pub mod request_review;
+pub mod batch_request_review;
 pub mod show;
 pub mod sync;
 pub mod create_patch;


### PR DESCRIPTION
You can do `gps brr 1 2 3 4` to rr patches 1, 2, 3 and 4.

Tested on my machine and it works.

closes #173 
