### PR TITLE
Add example list info hook

### DIFF
--- a/example_hooks/list_additional_information-github-cli-example
+++ b/example_hooks/list_additional_information-github-cli-example
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+patch_index=$1 # integer, git-ps index of the current patch
+patch_status=$2 # git-ps status of the patch. b / rr / int / rr+ ↓ etc.
+patch_oid=$3 # commit SHA
+patch_summary=$4 # the first line of the commit message
+
+echo $3


### PR DESCRIPTION
Add an example list_additional_information hook so that users of gps can refer to it and discover the full capabilities of this feature.

There will also be a reference to this example from the docs.

FI-123

<!-- ps-id: 83b954a1-19a9-4feb-bdfc-dda2a3bfc463 -->