### PR TITLE
Use Path and PathBuf in hook detection logic

### DIFF
--- a/src/ps/private/hooks.rs
+++ b/src/ps/private/hooks.rs
@@ -10,21 +10,22 @@ pub enum FindHookError {
 }
 
 pub fn find_hook(repo_root: &str, filename: &str) -> Result<PathBuf, FindHookError> {
-  let communal_repository_level_hook_path_string = format!("{}/.git-ps/hooks/{}", repo_root, filename);
-  let communal_repository_level_hook_path = Path::new(communal_repository_level_hook_path_string.as_str());
-  let repository_level_hook_path_string = format!("{}/.git/git-ps/hooks/{}", repo_root, filename);
-  let repository_level_hook_path = Path::new(repository_level_hook_path_string.as_str());
-  let user_level_hook_path_string = format!("~/.config/git-ps/hooks/{}", filename);
-  let user_level_hook_path = Path::new(user_level_hook_path_string.as_str()).expand_home().map_err(FindHookError::PathExpandHomeFailed)?;
-  match path_exists_and_is_executable(communal_repository_level_hook_path) {
-    PathExistsAndIsExecutable::ExistsAndIsExecutable => Ok(communal_repository_level_hook_path.to_path_buf()),
-    PathExistsAndIsExecutable::ExistsButNotExecutable => Err(FindHookError::NotExecutable(communal_repository_level_hook_path.to_path_buf())),
-    PathExistsAndIsExecutable::DoesNotExist => match path_exists_and_is_executable(repository_level_hook_path) {
-      PathExistsAndIsExecutable::ExistsAndIsExecutable => Ok(repository_level_hook_path.to_path_buf()),
-      PathExistsAndIsExecutable::ExistsButNotExecutable => Err(FindHookError::NotExecutable(repository_level_hook_path.to_path_buf())),
-      PathExistsAndIsExecutable::DoesNotExist => match path_exists_and_is_executable(&user_level_hook_path) {
-        PathExistsAndIsExecutable::ExistsAndIsExecutable => Ok(user_level_hook_path.to_path_buf()),
-        PathExistsAndIsExecutable::ExistsButNotExecutable => Err(FindHookError::NotExecutable(user_level_hook_path.to_path_buf())),
+  let communal_repository_level_hook_pathbuf: PathBuf = [repo_root, ".git-ps", "hooks", filename].iter().collect();
+  let repository_level_hook_pathbuf: PathBuf = [repo_root, ".git", "git-ps", "hooks", filename].iter().collect();
+  let mut user_level_hook_pathbuf = "~".expand_home().map_err(FindHookError::PathExpandHomeFailed)?;
+  user_level_hook_pathbuf.push(".config");
+  user_level_hook_pathbuf.push("git-ps");
+  user_level_hook_pathbuf.push("hooks");
+  user_level_hook_pathbuf.push(filename);
+  match path_exists_and_is_executable(communal_repository_level_hook_pathbuf.as_path()) {
+    PathExistsAndIsExecutable::ExistsAndIsExecutable => Ok(communal_repository_level_hook_pathbuf),
+    PathExistsAndIsExecutable::ExistsButNotExecutable => Err(FindHookError::NotExecutable(communal_repository_level_hook_pathbuf)),
+    PathExistsAndIsExecutable::DoesNotExist => match path_exists_and_is_executable(repository_level_hook_pathbuf.as_path()) {
+      PathExistsAndIsExecutable::ExistsAndIsExecutable => Ok(repository_level_hook_pathbuf),
+      PathExistsAndIsExecutable::ExistsButNotExecutable => Err(FindHookError::NotExecutable(repository_level_hook_pathbuf)),
+      PathExistsAndIsExecutable::DoesNotExist => match path_exists_and_is_executable(&user_level_hook_pathbuf.as_path()) {
+        PathExistsAndIsExecutable::ExistsAndIsExecutable => Ok(user_level_hook_pathbuf),
+        PathExistsAndIsExecutable::ExistsButNotExecutable => Err(FindHookError::NotExecutable(user_level_hook_pathbuf)),
         PathExistsAndIsExecutable::DoesNotExist => Err(FindHookError::NotFound)
       }
     }


### PR DESCRIPTION
This should alleviate the repeated separators reported in #172.
