### PR TITLE
Exit gps on error

### DIFF
--- a/src/commands/add_changes_to_stage.rs
+++ b/src/commands/add_changes_to_stage.rs
@@ -3,6 +3,9 @@ use gps as ps;
 pub fn add_changes_to_stage(interactive: bool, patch: bool, edit: bool, all: bool, files: Vec<std::string::String>) {
   match ps::add_changes_to_stage(interactive, patch, edit, all, files) {
     Ok(_) => {},
-    Err(e) => eprintln!("Error: {:?}", e)
+    Err(e) => {
+      eprintln!("Error: {:?}", e);
+      std::process::exit(1);
+    }
   }
 }

--- a/src/commands/amend_patch.rs
+++ b/src/commands/amend_patch.rs
@@ -3,6 +3,9 @@ use gps as ps;
 pub fn amend_patch(no_edit: bool) {
   match ps::amend_patch(no_edit) {
     Ok(_) => {},
-    Err(e) => eprintln!("Error: {:?}", e)
+    Err(e) => {
+      eprintln!("Error: {:?}", e);
+      std::process::exit(1);
+    }
   }
 }

--- a/src/commands/backup_stack.rs
+++ b/src/commands/backup_stack.rs
@@ -4,6 +4,9 @@ use std::string::String;
 pub fn backup_stack(branch_name: String) {
   match ps::backup_stack(branch_name) {
     Ok(_) => {},
-    Err(e) => eprintln!("Error: {:?}", e)
+    Err(e) => {
+      eprintln!("Error: {:?}", e);
+      std::process::exit(1);
+    }
   }
 }

--- a/src/commands/batch_request_review.rs
+++ b/src/commands/batch_request_review.rs
@@ -3,6 +3,9 @@ use gps as ps;
 pub fn batch_request_review(patch_indexes: Vec<usize>, color: bool) {
   match ps::batch_request_review(patch_indexes, color) {
     Ok(_) => {},
-    Err(e) => eprintln!("Error: {:?}", e)
-  };
+    Err(e) => {
+      eprintln!("Error: {:?}", e);
+      std::process::exit(1);
+    }
+  }
 }

--- a/src/commands/branch.rs
+++ b/src/commands/branch.rs
@@ -5,6 +5,9 @@ use std::string::String;
 pub fn branch(start_patch_index: usize, end_patch_index_option: Option<usize>, branch_name: String) {
   match ps::branch(start_patch_index, end_patch_index_option, branch_name) {
     Ok(_) => {},
-    Err(e) => eprintln!("Error: {:?}", e)
+    Err(e) => {
+      eprintln!("Error: {:?}", e);
+      std::process::exit(1);
+    }
   }
 }

--- a/src/commands/checkout.rs
+++ b/src/commands/checkout.rs
@@ -4,6 +4,9 @@ pub fn checkout(patch_index: usize) {
   let res = ps::checkout(patch_index);
   match res {
     Ok(_) => {},
-    Err(e) => eprintln!("Error: {:?}", e)
+    Err(e) => {
+      eprintln!("Error: {:?}", e);
+      std::process::exit(1);
+    }
   }
 }

--- a/src/commands/create_patch.rs
+++ b/src/commands/create_patch.rs
@@ -3,6 +3,9 @@ use gps as ps;
 pub fn create_patch() {
   match ps::create_patch() {
     Ok(_) => {},
-    Err(e) => eprintln!("Error: {:?}", e)
+    Err(e) => {
+      eprintln!("Error: {:?}", e);
+      std::process::exit(1);
+    }
   }
 }

--- a/src/commands/fetch.rs
+++ b/src/commands/fetch.rs
@@ -3,6 +3,9 @@ use gps as ps;
 pub fn fetch(color: bool) {
   match ps::fetch(color) {
     Ok(_) => {},
-    Err(e) => eprintln!("Error: {:?}", e)
+    Err(e) => {
+      eprintln!("Error: {:?}", e);
+      std::process::exit(1);
+    }
   };
 }

--- a/src/commands/integrate.rs
+++ b/src/commands/integrate.rs
@@ -13,8 +13,12 @@ r#"
   sync'd or requested review of this patch.
 
   To get caught up just sync or request-review the patch again.
-"#)
+"#);
+      std::process::exit(1);
     }
-    Err(e) => print_err(color, format!("\nError: {:?}\n", e).as_str())
+    Err(e) => {
+      print_err(color, format!("\nError: {:?}\n", e).as_str());
+      std::process::exit(1);
+    }
   }
 }

--- a/src/commands/isolate.rs
+++ b/src/commands/isolate.rs
@@ -4,6 +4,9 @@ use super::utils::print_err;
 pub fn isolate(patch_index: Option<usize>, color: bool) {
   match ps::isolate(patch_index, color) {
     Ok(_) => {},
-    Err(e) => print_err(color, format!("\nError: {:?}\n", e).as_str())
+    Err(e) => {
+      print_err(color, format!("\nError: {:?}\n", e).as_str());
+      std::process::exit(1);
+    }
   }
 }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -10,6 +10,9 @@ use gps as ps;
 pub fn list(color: bool) {
   match ps::list(color) {
     Ok(_) => {},
-    Err(e) => eprintln!("Error: {:?}", e)
+    Err(e) => {
+      eprintln!("Error: {:?}", e);
+      std::process::exit(1);
+    }
   };
 }

--- a/src/commands/log.rs
+++ b/src/commands/log.rs
@@ -3,6 +3,9 @@ use gps as ps;
 pub fn log() {
   match ps::log() {
     Ok(_) => {},
-    Err(e) => eprintln!("Error: {:?}", e)
+    Err(e) => {
+      eprintln!("Error: {:?}", e);
+      std::process::exit(1);
+    }
   };
 }

--- a/src/commands/pull.rs
+++ b/src/commands/pull.rs
@@ -6,7 +6,10 @@ pub fn pull(color: bool) {
 
   match ps::pull(color) {
     Ok(_) => {},
-    Err(e) => eprintln!("Error: {:?}", e)
+    Err(e) => {
+      eprintln!("Error: {:?}", e);
+      std::process::exit(1);
+    }
   };
 
   if let Ok(newer_release) = check_release_thread.join().expect("Check release thread panicked!") {

--- a/src/commands/rebase.rs
+++ b/src/commands/rebase.rs
@@ -10,6 +10,9 @@ use gps as ps;
 pub fn rebase(continue_rebase: bool) {
   match ps::rebase(continue_rebase) {
     Ok(_) => return,
-    Err(e) => eprintln!("Error: {:?}", e)
+    Err(e) => {
+      eprintln!("Error: {:?}", e);
+      std::process::exit(1);
+    }
   };
 }

--- a/src/commands/request_review.rs
+++ b/src/commands/request_review.rs
@@ -54,7 +54,11 @@ r#"
     chmod u+x {}
 "#, path_str, path_str);
       print_err(color, &msg);
+      std::process::exit(1);
     },
-    Err(e) => print_err(color, format!("\nError: {}\n", e).as_str())
+    Err(e) => {
+      print_err(color, format!("\nError: {}\n", e).as_str());
+      std::process::exit(1);
+    }
   };
 }

--- a/src/commands/request_review_branch.rs
+++ b/src/commands/request_review_branch.rs
@@ -6,6 +6,9 @@ pub fn request_review_branch(patch_index: usize, branch_name: Option<String>) {
   let res = ps::request_review_branch(patch_index, branch_name);
   match res {
     Ok(_) => {},
-    Err(e) => eprintln!("Error: {:?}", e)
+    Err(e) => {
+      eprintln!("Error: {:?}", e);
+      std::process::exit(1);
+    }
   }
 }

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -3,6 +3,9 @@ use gps as ps;
 pub fn show(patch_index: usize) {
   match ps::show(patch_index) {
     Ok(_) => return,
-    Err(e) => eprintln!("Error: {:?}", e)
+    Err(e) => {
+      eprintln!("Error: {:?}", e);
+      std::process::exit(1);
+    }
   };
 }

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -3,6 +3,9 @@ use gps as ps;
 pub fn status() {
   match ps::status() {
     Ok(_) => {},
-    Err(e) => eprintln!("Error: {:?}", e)
+    Err(e) => {
+      eprintln!("Error: {:?}", e);
+      std::process::exit(1);
+    }
   }
 }

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -4,6 +4,9 @@ pub fn sync(patch_index: usize, branch_name: Option<String>) {
   let res = ps::sync(patch_index, branch_name);
   match res {
     Ok(_) => return,
-    Err(e) => eprintln!("Error: {:?}", e)
+    Err(e) => {
+      eprintln!("Error: {:?}", e);
+      std::process::exit(1);
+    }
   }
 }

--- a/src/commands/unstage.rs
+++ b/src/commands/unstage.rs
@@ -3,6 +3,9 @@ use gps as ps;
 pub fn unstage(files: Vec<std::string::String>) {
   match ps::unstage(files) {
     Ok(_) => {},
-    Err(e) => eprintln!("Error: {:?}", e)
+    Err(e) => {
+      eprintln!("Error: {:?}", e);
+      std::process::exit(1);
+    }
   }
 }

--- a/src/commands/upstream_patches.rs
+++ b/src/commands/upstream_patches.rs
@@ -11,6 +11,9 @@ use gps as ps;
 pub fn upstream_patches(color: bool) {
   match ps::upstream_patches(color) {
     Ok(_) => {},
-    Err(e) => eprintln!("Error: {:?}", e)
+    Err(e) => {
+      eprintln!("Error: {:?}", e);
+      std::process::exit(1);
+    }
   };
 }


### PR DESCRIPTION
Fixes #192.

We could cleanup the error handling logic a bit more so that we exit at the very end, however this makes printing multiple error messages trickier and I haven't found a good way to do it. At least for the moment it solves #192.
