### PR TITLE
fix some warnings about dead code

### DIFF
--- a/src/commands/backup_stack.rs
+++ b/src/commands/backup_stack.rs
@@ -1,6 +1,7 @@
 use gps as ps;
 use std::string::String;
 
+#[allow(dead_code)]
 pub fn backup_stack(branch_name: String) {
   match ps::backup_stack(branch_name) {
     Ok(_) => {},

--- a/src/ps/private/git.rs
+++ b/src/ps/private/git.rs
@@ -510,6 +510,7 @@ pub enum HashObjectWriteError {
   Failed(git2::Error)
 }
 
+#[allow(dead_code)]
 pub fn hash_object_write(repo: &git2::Repository, content: &str) -> Result<git2::Oid, HashObjectWriteError> {
   repo.blob(content.as_bytes()).map_err(HashObjectWriteError::Failed)
 }
@@ -520,6 +521,7 @@ pub enum ReadHashedObjectError {
   Failed(git2::Error)
 }
 
+#[allow(dead_code)]
 pub fn read_hashed_object(repo: &git2::Repository, oid: git2::Oid) -> Result<String, ReadHashedObjectError> {
   let blob = repo.find_blob(oid).map_err(ReadHashedObjectError::Failed)?;
   let content = blob.content();
@@ -530,7 +532,7 @@ pub fn read_hashed_object(repo: &git2::Repository, oid: git2::Oid) -> Result<Str
 #[cfg(test)]
 mod tests {
   use tempfile::TempDir;
-  use git2::{Repository, RepositoryInitOptions, Sort};
+  use git2::{Repository, RepositoryInitOptions};
 
   pub fn repo_init() -> (TempDir, Repository) {
       let td = TempDir::new().unwrap();

--- a/src/ps/private/hooks.rs
+++ b/src/ps/private/hooks.rs
@@ -1,4 +1,4 @@
-use std::{path::{Path, PathBuf}, process::Output};
+use std::{path::{PathBuf}, process::Output};
 use super::{paths::{PathExistsAndIsExecutable, path_exists_and_is_executable, self}, utils};
 use home_dir::{self, HomeDirExt};
 

--- a/src/ps/private/state_management.rs
+++ b/src/ps/private/state_management.rs
@@ -147,6 +147,7 @@ pub fn fetch_patch_meta_data(repo: &git2::Repository, patch_id: &Uuid) -> Result
   Ok(patch_meta_data.get(patch_id).cloned())
 }
 
+#[allow(dead_code)]
 pub fn get_patch_reference_name(patch_id: Uuid) -> String {
   format!("refs/gps-patch-metadata/{}", patch_id)
 }


### PR DESCRIPTION
If we are going to keep dead code around, we might as well mark it as such and fix the warnings.