### PR TITLE
ignore nix profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 
 .vscode/*
+
+nix/profiles/*


### PR DESCRIPTION
This is useful since I use Nix to develop in this repo. If these files are not ignored they keep messing with gps. These files just make it so that I can quickly load my dev environment.