### PR TITLE
gps branch: auto-generate names when -n not provided

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,7 +22,7 @@ pub struct BranchCmdOpts {
   pub end_patch_index: Option<usize>,
   /// Use the provided branch name instead of generating one
   #[structopt(short = "n")]
-  pub branch_name: String
+  pub branch_name: Option<String>
 }
 
 #[derive(Debug, StructOpt)]

--- a/src/commands/branch.rs
+++ b/src/commands/branch.rs
@@ -2,7 +2,7 @@ use gps as ps;
 use std::option::Option;
 use std::string::String;
 
-pub fn branch(start_patch_index: usize, end_patch_index_option: Option<usize>, branch_name: String) {
+pub fn branch(start_patch_index: usize, end_patch_index_option: Option<usize>, branch_name: Option<String>) {
   match ps::branch(start_patch_index, end_patch_index_option, branch_name) {
     Ok(_) => {},
     Err(e) => {

--- a/src/ps/public/branch.rs
+++ b/src/ps/public/branch.rs
@@ -5,24 +5,25 @@ use std::result::Result;
 
 #[derive(Debug)]
 pub enum BranchError {
-    OpenRepositoryFailed(git::CreateCwdRepositoryError),
-    GetPatchStackFailed(ps::PatchStackError),
-    PatchStackBaseNotFound,
-    GetPatchListFailed(ps::GetPatchListError),
-    PatchIndexNotFound,
-    CreateBranchFailed(git2::Error),
-    BranchNameNotUtf8,
-    FindCommitFailed(git2::Error),
-    GetCommitParentZeroFailed(git2::Error),
-    CherryPickFailed(git::GitError),
-    OpenGitConfigFailed(git2::Error),
+  OpenRepositoryFailed(git::CreateCwdRepositoryError),
+  GetPatchStackFailed(ps::PatchStackError),
+  PatchStackBaseNotFound,
+  GetPatchListFailed(ps::GetPatchListError),
+  PatchIndexNotFound,
+  CreateBranchFailed(git2::Error),
+  BranchNameNotUtf8,
+  PatchSummaryMissing,
+  FindCommitFailed(git2::Error),
+  GetCommitParentZeroFailed(git2::Error),
+  CherryPickFailed(git::GitError),
+  OpenGitConfigFailed(git2::Error)
 }
 
 pub fn branch(
     start_patch_index: usize,
     end_patch_index_option: Option<usize>,
-    branch_name: String,
-) -> Result<(), BranchError> {
+    branch_name: Option<String>
+) -> Result<(), BranchError>  {
     let repo = git::create_cwd_repo().map_err(BranchError::OpenRepositoryFailed)?;
     let config = git2::Config::open_default().map_err(BranchError::OpenGitConfigFailed)?;
 
@@ -33,64 +34,69 @@ pub fn branch(
         .peel_to_commit()
         .map_err(|_| BranchError::PatchStackBaseNotFound)?;
 
-    if let Some(end_patch_index) = end_patch_index_option {
-        // find the patch series in the patch stack
-        let patches_vec =
-            ps::get_patch_list(&repo, &patch_stack).map_err(BranchError::GetPatchListFailed)?;
-        let start_patch_oid = patches_vec
-            .get(start_patch_index)
-            .ok_or(BranchError::PatchIndexNotFound)?
-            .oid;
-        let end_patch_oid = patches_vec
-            .get(end_patch_index)
-            .ok_or(BranchError::PatchIndexNotFound)?
-            .oid;
+  // find the patch series in the patch stack
+  let patches_vec =
+      ps::get_patch_list(&repo, &patch_stack).map_err(BranchError::GetPatchListFailed)?;
+  let start_patch_oid = patches_vec
+      .get(start_patch_index)
+      .ok_or(BranchError::PatchIndexNotFound)?
+      .oid;
 
-        // translate the patch series to bounds for the cherry-pick range
-        let start_patch_commit = repo
-            .find_commit(start_patch_oid)
-            .map_err(BranchError::FindCommitFailed)?;
-        let start_patch_parent_commit = start_patch_commit
-            .parent(0)
-            .map_err(BranchError::GetCommitParentZeroFailed)?;
-        let start_patch_parent_oid = start_patch_parent_commit.id();
+  // translate the patch series to bounds for the cherry-pick range
+  let start_patch_commit = repo
+      .find_commit(start_patch_oid)
+      .map_err(BranchError::FindCommitFailed)?;
+  let start_patch_parent_commit = start_patch_commit
+      .parent(0)
+      .map_err(BranchError::GetCommitParentZeroFailed)?;
+  let start_patch_parent_oid = start_patch_parent_commit
+      .id();
 
-        // create a branch on the base of the current patch stack
-        let branch = repo
-            .branch(branch_name.as_str(), &patch_stack_base_commit, true)
-            .map_err(BranchError::CreateBranchFailed)?;
-        let branch_ref_name = branch.get().name().ok_or(BranchError::BranchNameNotUtf8)?;
-
-        // cherry-pick the series of patches into the new branch
-        git::cherry_pick_no_working_copy_range(
-            &repo,
-            &config,
-            end_patch_oid,
-            start_patch_parent_oid,
-            branch_ref_name,
-        )
-        .map_err(BranchError::CherryPickFailed)?;
-        git::cherry_pick_no_working_copy(&repo, &config, end_patch_oid, branch_ref_name, 0)
-            .map_err(BranchError::CherryPickFailed)?;
-    } else {
-        // find the patch in the patch stack
-        let patches_vec =
-            ps::get_patch_list(&repo, &patch_stack).map_err(BranchError::GetPatchListFailed)?;
-        let patch_oid = patches_vec
-            .get(start_patch_index)
-            .ok_or(BranchError::PatchIndexNotFound)?
-            .oid;
-
-        // create a branch on the base of the current patch stack
-        let branch = repo
-            .branch(branch_name.as_str(), &patch_stack_base_commit, true)
-            .map_err(BranchError::CreateBranchFailed)?;
-        let branch_ref_name = branch.get().name().ok_or(BranchError::BranchNameNotUtf8)?;
-
-        // cherry-pick the single patch into the new branch
-        git::cherry_pick_no_working_copy(&repo, &config, patch_oid, branch_ref_name, 0)
-            .map_err(BranchError::CherryPickFailed)?;
+  // Generate a branch name if one was not provided
+  let branch_name = match branch_name {
+    Some(name) => name,
+    None => {
+      let mut branch_name = String::from("gps-branch-");
+      let patch_summary = start_patch_commit
+          .summary().ok_or(BranchError::PatchSummaryMissing)?;
+      let default_branch_name = ps::generate_rr_branch_name(patch_summary);
+      branch_name.push_str(&default_branch_name);
+      branch_name
     }
+  };
+
+  if let Some(end_patch_index) = end_patch_index_option {
+    // find the patch series in the patch stack
+    let end_patch_oid = patches_vec
+        .get(end_patch_index)
+        .ok_or(BranchError::PatchIndexNotFound)?
+        .oid;
+
+    // create a branch on the base of the current patch stack
+    let branch = repo.branch(branch_name
+        .as_str(), &patch_stack_base_commit, false)
+        .map_err(BranchError::CreateBranchFailed)?;
+    let branch_ref_name = branch
+        .get()
+        .name()
+        .ok_or(BranchError::BranchNameNotUtf8)?;
+
+    // cherry-pick the series of patches into the new branch
+    git::cherry_pick_no_working_copy_range(&repo, &config, end_patch_oid, start_patch_parent_oid, branch_ref_name).map_err(BranchError::CherryPickFailed)?;
+    git::cherry_pick_no_working_copy(&repo, &config, end_patch_oid, branch_ref_name, 0).map_err(BranchError::CherryPickFailed)?;
+  } else {
+    // create a branch on the base of the current patch stack
+    let branch = repo.branch(branch_name
+        .as_str(), &patch_stack_base_commit, false)
+        .map_err(BranchError::CreateBranchFailed)?;
+    let branch_ref_name = branch
+        .get()
+        .name()
+        .ok_or(BranchError::BranchNameNotUtf8)?;
+
+    // cherry-pick the single patch into the new branch
+    git::cherry_pick_no_working_copy(&repo, &config, start_patch_oid, branch_ref_name, 0).map_err(BranchError::CherryPickFailed)?;
+  }
 
     Ok(())
 }


### PR DESCRIPTION
We now autogenerate names for `gps branch` when the optional `-n` argument is not provided. The naming schema is slightly different to that of `gps rr` since we don't want to have a conflict. Therefore we simply prepend `gps-branch-` to the `rr` name of the first patch.

Signed-off-by: Ali Caglayan <alizter@gmail.com>

<!-- ps-id: dd9a23d4-4fe3-4f5e-9600-e1a2bf9d752c -->