### PR TITLE
Add macos and windows runners to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,13 +8,20 @@ name: Test
 
 jobs:
   test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
     name: Test
     env:
       PROJECT_NAME_UNDERSCORE: git_ps_ci_github_actions_workflow
       CARGO_INCREMENTAL: 0
       # RUSTFLAGS: -Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort
       # RUSTDOCFLAGS: -Cpanic=abort
-    runs-on: ubuntu-latest
+    runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -35,9 +42,6 @@ jobs:
             ~/.cargo/registry/cache
             target
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('Cargo.lock') }}
-      - name: Install GPGME
-        run: |
-          sudo apt-get install -y libgpgme-dev
       - name: Run Tests
         run: |
           cargo test


### PR DESCRIPTION
Add macos and windows runners to CI so that we can make sure that as
changes are introduced that we continue to be able to build for unix
based platforms, macos, and windows.

This relates to issue #218.

Signed-off-by: Ali Caglayan <alizter@gmail.com>

<!-- ps-id: 807cf6ba-18b3-4531-8f95-a62740a3ae96 -->