### PR TITLE
Fix windows support for utils/execute.rs

### DIFF
--- a/src/ps/private/utils/execute.rs
+++ b/src/ps/private/utils/execute.rs
@@ -1,9 +1,5 @@
 use std::io;
-#[cfg(target_family = "unix")]
-use std::os::unix::process::ExitStatusExt;
-#[cfg(target_family = "windows")]
-use std::os::windows::process::ExitStatusExt;
-use std::process::{Command, Output};
+use std::process::{Command, Output, ExitStatus};
 use std::result::Result;
 
 #[derive(Debug)]
@@ -13,6 +9,19 @@ pub enum ExecuteError {
     ExitStatus(i32),
     ExitSignal(i32),
     ExitMissingSignal, // triggered when we understand exit to be triggered by signal but no signal found
+}
+
+#[cfg(target_family = "unix")]
+fn handle_error_no_code(status: ExitStatus) -> ExecuteError {
+    match status.signal() {
+        Some(signal) => return ExecuteError::ExitSignal(signal),
+        None => return ExecuteError::ExitMissingSignal,
+    }
+}
+
+#[cfg(target_family = "windows")]
+fn handle_error_no_code(_: ExitStatus) -> ExecuteError {
+    return ExecuteError::ExitMissingSignal
 }
 
 /// Execute an external command in the foreground allowing it to take over the
@@ -27,13 +36,10 @@ pub fn execute(exe: &str, args: &[&str]) -> Result<(), ExecuteError> {
                 if status.success() {
                     Ok(())
                 } else {
-                    match status.code() {
-                        Some(code) => Err(ExecuteError::ExitStatus(code)),
-                        None => match status.signal() {
-                            Some(signal) => Err(ExecuteError::ExitSignal(signal)),
-                            None => Err(ExecuteError::ExitMissingSignal),
-                        },
-                    }
+                    Err (match status.code() {
+                        Some(code) => ExecuteError::ExitStatus(code),
+                        None => handle_error_no_code(status)
+                    })
                 }
             }
         },


### PR DESCRIPTION
The following are traits
```
std::os::unix::process::ExitStatusExt
std::os::windows::process::ExitStatusExt
```
added to
```
std::process:ExitStatus
```
Therefore functions specific to unix cannot be used in windows. To fix this, we make a function to handle the final error code on both unix and windows. On unix, we further check for a signal, which cannot be done for windows.

I developed this on windows and it gets the compilation further. There is a final issue with the linking because I am missing some dependencies on Windows which will take some time to download.
