### PR TITLE
chore: fix warning on windows

### DIFF
--- a/src/ps/private/utils/execute.rs
+++ b/src/ps/private/utils/execute.rs
@@ -1,8 +1,6 @@
 use std::io::{self, Write};
 #[cfg(target_family = "unix")]
 use std::os::unix::process::ExitStatusExt;
-#[cfg(target_family = "windows")]
-use std::os::windows::process::ExitStatusExt;
 use std::process::{Command, ExitStatus, Output, Stdio};
 use std::result::Result;
 


### PR DESCRIPTION
This `use` was unused.

<!-- ps-id: d3fa8e55-c7f1-4d2b-a0b2-8aec33e89a82 -->