### PR TITLE
skip hook is executable check on windows

### DIFF
--- a/src/ps/private/paths.rs
+++ b/src/ps/private/paths.rs
@@ -81,8 +81,8 @@ pub enum PathExistsAndIsExecutable {
 }
 
 pub fn path_exists_and_is_executable(path: &Path) -> PathExistsAndIsExecutable {
-    if path.exists() {
-        if path.is_executable() {
+    if path.exists() { 
+        if path.is_executable()  || cfg!(target_os = "windows") {
             PathExistsAndIsExecutable::ExistsAndIsExecutable
         } else {
             PathExistsAndIsExecutable::ExistsButNotExecutable


### PR DESCRIPTION
This has the unintended affect of making it difficult to use `gps` on this very repo since we have hooks in `.git-ps/` and they don't work on Windows.