### PR TITLE
feature: color configuration for gps list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,14 +85,15 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
+ "serde",
  "winapi",
 ]
 
 [[package]]
 name = "anstream"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
+checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -110,20 +111,20 @@ checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -133,7 +134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -225,8 +226,8 @@ dependencies = [
  "cfg-if",
  "event-listener 3.0.0",
  "futures-lite",
- "rustix 0.38.19",
- "windows-sys",
+ "rustix 0.38.28",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -237,7 +238,7 @@ checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.47",
 ]
 
 [[package]]
@@ -252,10 +253,10 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.19",
+ "rustix 0.38.28",
  "signal-hook-registry",
  "slab",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -272,7 +273,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.47",
 ]
 
 [[package]]
@@ -295,9 +296,9 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.21.4"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
+checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
 name = "base64ct"
@@ -324,9 +325,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "block-buffer"
@@ -446,7 +447,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -470,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.6"
+version = "4.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956"
+checksum = "dcfab8ba68f3668e89f6ff60f5b205cea56aa7b769451a59f34b8682f51c056d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -480,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.6"
+version = "4.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e231faeaca65ebd1ea3c737966bf858971cd38c3849107aa3ea7de90a804e45"
+checksum = "fb7fb5e4e979aec3be7791562fcba452f94ad85e954da024396433e0e25a79e9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -492,36 +493,36 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.4.3"
+version = "4.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ae8ba90b9d8b007efe66e55e48fb936272f5ca00349b5b0e89877520d35ea7"
+checksum = "97aeaa95557bd02f23fbb662f981670c3d20c5a26e69f7354b28f57092437fcd"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.4.2"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.47",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "clap_mangen"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b44f35c514163027542f7147797ff930523eea288e03642727348ef1a9666f6b"
+checksum = "10b5db60b3310cdb376fbeb8826e875a38080d0c61bdec0a91a3da8338948736"
 dependencies = [
  "clap",
  "roff",
@@ -544,9 +545,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "core-foundation"
@@ -566,9 +567,9 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
 dependencies = [
  "libc",
 ]
@@ -593,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.3"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740fe28e594155f10cfc383984cbefd529d7396050557148f79cb0f621204124"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -640,13 +641,13 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek-derive"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.47",
 ]
 
 [[package]]
@@ -684,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.16.8"
+version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b1e0c257a9e9f25f90ff76d7a68360ed497ee519c8e428d1825ef0000799d4"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
  "digest",
@@ -698,29 +699,30 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "2.2.2"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60f6d271ca33075c88028be6f04d502853d63a5ece419d269c15315d4fc1cf1d"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "signature",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7277392b266383ef8396db7fdeb1e77b6c52fed775f5df15bb24f35b72156980"
+checksum = "1f628eaec48bfd21b865dc2950cfa014450c01d2fa2b69a86c2fd5844ec523c0"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
  "sha2",
+ "subtle",
 ]
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.6"
+version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97ca172ae9dc9f9b779a6e3a65d308f2af74e5b8c921299075bdb4a0370e914"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -753,7 +755,7 @@ checksum = "f95e2801cd355d4a1a3e3953ce6ee5ae9603a5c833455343a8bfe3f44d418246"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.47",
 ]
 
 [[package]]
@@ -764,12 +766,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.5"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -816,15 +818,15 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.1"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0870c84016d4b481be5c9f323c24f65e31e901ae618f0e80f4308fb00de1d2d"
+checksum = "53a56f0780318174bad1c127063fd0c5fdfb35398e3cd79ffaab931a6c79df80"
 
 [[package]]
 name = "flate2"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -832,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
@@ -910,7 +912,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.47",
 ]
 
 [[package]]
@@ -956,9 +958,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1078,7 +1080,7 @@ dependencies = [
  "nix",
  "serde",
  "widestring",
- "windows-sys",
+ "windows-sys 0.48.0",
  "wmi",
 ]
 
@@ -1107,9 +1109,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -1152,7 +1154,7 @@ checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1208,14 +1210,14 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
- "spin",
+ "spin 0.5.2",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "libgit2-sys"
@@ -1281,9 +1283,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
+checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 
 [[package]]
 name = "log"
@@ -1293,9 +1295,9 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "memoffset"
@@ -1424,9 +1426,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opaque-debug"
@@ -1442,9 +1444,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.93"
+version = "0.9.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
+checksum = "c1665caf8ab2dc9aef43d1c0023bd904633a6a05cb30b0ad59bec2ae986e57a7"
 dependencies = [
  "cc",
  "libc",
@@ -1487,6 +1489,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "rand_core",
+ "sha2",
+]
+
+[[package]]
 name = "parking"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1512,9 +1528,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project-lite"
@@ -1562,15 +1578,15 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
 
 [[package]]
 name = "platforms"
-version = "3.1.2"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4503fa043bf02cee09a9582e9554b4c6403b2ef55e4612e96561d294419429f8"
+checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
 
 [[package]]
 name = "polling"
@@ -1585,7 +1601,7 @@ dependencies = [
  "libc",
  "log",
  "pin-project-lite",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1619,9 +1635,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "primeorder"
-version = "0.13.2"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c2fcef82c0ec6eefcc179b978446c399b3cdf73c392c35604e399eee6df1ee3"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
 ]
@@ -1633,23 +1649,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.19.15",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "907a61bd0f64c2f29cd1cf1dc34d05176426a3f504a78010f08416ddb7b13708"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -1686,18 +1702,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.0"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d119d7c7ca818f8a53c300863d4f87566aac09943aef5b355bb83969dae75d87"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1707,9 +1723,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465c6fc0621e4abc4187a2bda0937bfd4f722c2730b29562e19689ea796c9a4b"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1718,9 +1734,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56d84fdd47036b038fc80dd333d10b6aab10d5d31f4a366e20014def75328d33"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rfc6979"
@@ -1734,17 +1750,16 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
+version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
 dependencies = [
  "cc",
+ "getrandom",
  "libc",
- "once_cell",
- "spin",
+ "spin 0.9.8",
  "untrusted",
- "web-sys",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1755,27 +1770,25 @@ checksum = "b833d8d034ea094b1ea68aa6d5c740e0d04bad9d16568d08ba6f76823a114316"
 
 [[package]]
 name = "rpassword"
-version = "7.2.0"
+version = "7.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6678cf63ab3491898c0d021b493c94c9b221d91295294a2a5746eacbe5928322"
+checksum = "80472be3c897911d0137b2d2b9055faf6eeac5b14e324073d83bc17b191d7e3f"
 dependencies = [
  "libc",
  "rtoolbox",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "rsa"
-version = "0.9.2"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ab43bb47d23c1a631b4b680199a45255dce26fa9ab2fa902581f624ff13e6a8"
+checksum = "5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc"
 dependencies = [
- "byteorder",
  "const-oid",
  "digest",
  "num-bigint-dig",
  "num-integer",
- "num-iter",
  "num-traits",
  "pkcs1",
  "pkcs8",
@@ -1789,12 +1802,12 @@ dependencies = [
 
 [[package]]
 name = "rtoolbox"
-version = "0.0.1"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034e22c514f5c0cb8a10ff341b9b048b5ceb21591f31c8f44c43b960f9b3524a"
+checksum = "c247d24e63230cdb56463ae328478bd5eac8b8faa8c69461a77e8e323afac90e"
 dependencies = [
  "libc",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1817,27 +1830,27 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys 0.3.8",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.19"
+version = "0.38.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "745ecfa778e66b2b63c88a61cb36e0eea109e803b0b86bf9879fbc77c70e86ed"
+checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "errno",
  "libc",
- "linux-raw-sys 0.4.10",
- "windows-sys",
+ "linux-raw-sys 0.4.12",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.21.7"
+version = "0.21.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
+checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
  "ring",
@@ -1847,9 +1860,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.6"
+version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
  "untrusted",
@@ -1863,9 +1876,9 @@ checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "sct"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
  "untrusted",
@@ -1929,28 +1942,28 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 
 [[package]]
 name = "serde"
-version = "1.0.189"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
+checksum = "0b114498256798c94a0689e1a15fec6005dee8ac1f41de56404b67afc2a4b773"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.189"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
+checksum = "a3385e45322e8f9931410f01b3031ec534c3947d0e94c18049af4d9f9907d4e0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.47",
 ]
 
 [[package]]
@@ -1972,7 +1985,16 @@ checksum = "8725e1dfadb3a50f7e5ce0b1a540466f6ed3fe7a0fca2ac2b8b831d31316bd00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.47",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2008,9 +2030,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
  "rand_core",
@@ -2027,9 +2049,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
+checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
 name = "socket2"
@@ -2048,10 +2070,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
-name = "spki"
-version = "0.7.2"
+name = "spin"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
@@ -2087,15 +2115,16 @@ dependencies = [
 
 [[package]]
 name = "ssh-key"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728fdf5286c394f12d83eaad51190af629aade5494813ce6b57f7425f1ca51b7"
+checksum = "c51901eb883a5b442b506a1f8fa483d143f3bab513fe721e398ec56c77624feb"
 dependencies = [
  "bcrypt-pbkdf",
  "ed25519-dalek",
  "num-bigint-dig",
  "p256",
  "p384",
+ "p521",
  "rand_core",
  "rsa",
  "sec1",
@@ -2138,9 +2167,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "1726efe18f42ae774cc644f330953a5e7b3c3003d3edcecf18850fe9d4dd9afb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2149,15 +2178,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.8.0"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
+checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
 dependencies = [
  "cfg-if",
  "fastrand 2.0.1",
  "redox_syscall",
- "rustix 0.38.19",
- "windows-sys",
+ "rustix 0.38.28",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2177,7 +2206,7 @@ checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.47",
 ]
 
 [[package]]
@@ -2197,18 +2226,24 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
-version = "0.5.11"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
 dependencies = [
  "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.21.0",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -2217,6 +2252,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]
@@ -2241,7 +2289,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.47",
 ]
 
 [[package]]
@@ -2271,9 +2319,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+checksum = "6f2528f27a9eb2b21e69c95319b30bd0efd85d09c379741b0f78ea1d86be2416"
 
 [[package]]
 name = "unicode-ident"
@@ -2302,15 +2350,15 @@ dependencies = [
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.8.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5ccd538d4a604753ebc2f17cd9946e89b77bf87f6a8e2309667c6f2e87855e3"
+checksum = "f8cdd25c339e200129fe4de81451814e5228c9b771d57378817d6117cc2b3f97"
 dependencies = [
  "base64",
  "flate2",
@@ -2324,9 +2372,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2341,9 +2389,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.4.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 dependencies = [
  "getrandom",
  "serde",
@@ -2400,7 +2448,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.47",
  "wasm-bindgen-shared",
 ]
 
@@ -2422,7 +2470,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.47",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2434,20 +2482,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
-name = "web-sys"
-version = "0.3.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "webpki-roots"
-version = "0.25.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
+checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
 
 [[package]]
 name = "widestring"
@@ -2485,7 +2523,7 @@ checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2516,7 +2554,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -2525,13 +2572,28 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
 
 [[package]]
@@ -2541,10 +2603,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2553,10 +2627,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2565,16 +2651,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
@@ -2677,9 +2781,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 
 [[package]]
 name = "zvariant"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ regex = "1.5.6"
 lazy_static = "1.4.0"
 is_executable = "1.0.1"
 homedir = "0.2.1"
-toml = "0.5.9"
-ansi_term = "0.12.1"
+toml = "0.8.8"
+ansi_term = { version = "0.12.1", features = ["derive_serde_style"] }
 ureq = "2.4.0"
 version-compare = "0.1.0"
 ssh-key = { version = "0.6.1", features = ["alloc", "encryption", "ed25519", "rsa"] }

--- a/src/ps/private/config/get_config.rs
+++ b/src/ps/private/config/get_config.rs
@@ -4,7 +4,7 @@ use super::branch_config_dto::BranchConfigDto;
 use super::config_dto::ConfigDto;
 use super::fetch_config_dto::FetchConfigDto;
 use super::integrate_config_dto::IntegrateConfigDto;
-use super::list_config_dto::ListConfigDto;
+use super::list_config_dto::{ListConfigDto, ColorWithAlternate};
 use super::ps_config::{
     PsBranchConfig, PsConfig, PsFetchConfig, PsIntegrateConfig, PsListConfig, PsPullConfig,
     PsRequestReviewConfig,
@@ -12,6 +12,7 @@ use super::ps_config::{
 use super::pull_config_dto::PullConfigDto;
 use super::read_config_or_default::*;
 use super::request_review_config_dto::RequestReviewConfigDto;
+use ansi_term::Color;
 
 #[derive(Debug)]
 pub enum GetConfigError {
@@ -147,5 +148,29 @@ fn apply_list_config_defaults(list_config_dto: &ListConfigDto) -> PsListConfig {
         extra_patch_info_length: list_config_dto.extra_patch_info_length.unwrap_or(10),
         reverse_order: list_config_dto.reverse_order.unwrap_or(false),
         alternate_colors: list_config_dto.alternate_colors.unwrap_or(true),
+        patch_series_background: list_config_dto.patch_series_background.clone().unwrap_or_else(|| ColorWithAlternate {
+            color: None,
+            color_alternate: Some(Color::Fixed(237)), // super light grey
+        }),
+        patch_series_foreground: list_config_dto.patch_series_foreground.clone().unwrap_or_else(|| ColorWithAlternate {
+            color: None,
+            color_alternate: None
+        }),
+        patch_series_index: list_config_dto.patch_series_index.clone().unwrap_or_else(|| ColorWithAlternate {
+            color: Some(Color::Green),
+            color_alternate: None 
+        }),
+        patch_series_sha: list_config_dto.patch_series_sha.clone().unwrap_or_else(|| ColorWithAlternate {
+            color: Some(Color::Yellow),
+            color_alternate: None
+        }),
+        patch_series_summary: list_config_dto.patch_series_summary.clone().unwrap_or_else(|| ColorWithAlternate {
+            color: Some(Color::Cyan),
+            color_alternate: None
+        }),
+        patch_series_extra_patch_info: list_config_dto.patch_series_extra_patch_info.clone().unwrap_or_else(|| ColorWithAlternate {
+            color: Some(Color::Blue),
+            color_alternate: None
+        }),
     }
 }

--- a/src/ps/private/config/get_config.rs
+++ b/src/ps/private/config/get_config.rs
@@ -146,5 +146,6 @@ fn apply_list_config_defaults(list_config_dto: &ListConfigDto) -> PsListConfig {
         add_extra_patch_info: list_config_dto.add_extra_patch_info.unwrap_or(false),
         extra_patch_info_length: list_config_dto.extra_patch_info_length.unwrap_or(10),
         reverse_order: list_config_dto.reverse_order.unwrap_or(false),
+        alternate_colors: list_config_dto.alternate_colors.unwrap_or(true),
     }
 }

--- a/src/ps/private/config/list_config_dto.rs
+++ b/src/ps/private/config/list_config_dto.rs
@@ -7,6 +7,7 @@ pub struct ListConfigDto {
     pub add_extra_patch_info: Option<bool>,
     pub extra_patch_info_length: Option<usize>,
     pub reverse_order: Option<bool>,
+    pub alternate_colors: Option<bool>,
 }
 
 impl utils::Mergable for ListConfigDto {
@@ -16,6 +17,7 @@ impl utils::Mergable for ListConfigDto {
             add_extra_patch_info: b.add_extra_patch_info.or(self.add_extra_patch_info),
             extra_patch_info_length: b.extra_patch_info_length.or(self.extra_patch_info_length),
             reverse_order: b.reverse_order.or(self.reverse_order),
+            alternate_colors: b.alternate_colors.or(self.alternate_colors),
         }
     }
 }

--- a/src/ps/private/config/list_config_dto.rs
+++ b/src/ps/private/config/list_config_dto.rs
@@ -1,6 +1,29 @@
 use super::super::utils;
 use serde::Deserialize;
 use std::option::Option;
+use ansi_term::Color;
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct ColorWithAlternate {
+    pub color: Option<Color>,
+    pub color_alternate: Option<Color>
+}
+
+pub trait ColorSelector {
+    fn select_color(&self, is_alternate: bool) -> Option<Color>;
+}
+
+impl ColorSelector for ColorWithAlternate {
+    fn select_color(&self, is_alternate: bool) -> Option<Color> {
+        // If the alternative color is not set then use the main color.
+        let default = self.color.clone();
+        if is_alternate {
+            self.color_alternate.clone().or(default)
+        } else {
+            default
+        }
+    }
+}
 
 #[derive(Debug, Deserialize, Clone, Default)]
 pub struct ListConfigDto {
@@ -8,6 +31,12 @@ pub struct ListConfigDto {
     pub extra_patch_info_length: Option<usize>,
     pub reverse_order: Option<bool>,
     pub alternate_colors: Option<bool>,
+    pub patch_series_background: Option<ColorWithAlternate>,
+    pub patch_series_foreground: Option<ColorWithAlternate>,
+    pub patch_series_index: Option<ColorWithAlternate>,
+    pub patch_series_sha: Option<ColorWithAlternate>,
+    pub patch_series_summary: Option<ColorWithAlternate>,
+    pub patch_series_extra_patch_info: Option<ColorWithAlternate>,
 }
 
 impl utils::Mergable for ListConfigDto {
@@ -18,6 +47,12 @@ impl utils::Mergable for ListConfigDto {
             extra_patch_info_length: b.extra_patch_info_length.or(self.extra_patch_info_length),
             reverse_order: b.reverse_order.or(self.reverse_order),
             alternate_colors: b.alternate_colors.or(self.alternate_colors),
+            patch_series_background: b.patch_series_background.clone().or(self.patch_series_background.clone()),
+            patch_series_foreground: b.patch_series_foreground.clone().or(self.patch_series_foreground.clone()),
+            patch_series_index: b.patch_series_index.clone().or(self.patch_series_index.clone()),
+            patch_series_sha: b.patch_series_sha.clone().or(self.patch_series_sha.clone()),
+            patch_series_summary: b.patch_series_summary.clone().or(self.patch_series_summary.clone()),
+            patch_series_extra_patch_info: b.patch_series_extra_patch_info.clone().or(self.patch_series_extra_patch_info.clone()),
         }
     }
 }

--- a/src/ps/private/config/mod.rs
+++ b/src/ps/private/config/mod.rs
@@ -15,3 +15,4 @@ pub use config_dto::*;
 pub use get_config::*;
 pub use ps_config::*;
 pub use request_review_config_dto::*;
+pub use list_config_dto::ColorSelector;

--- a/src/ps/private/config/ps_config.rs
+++ b/src/ps/private/config/ps_config.rs
@@ -1,3 +1,5 @@
+use super::list_config_dto::ColorWithAlternate;
+
 #[derive(Debug)]
 pub struct PsConfig {
     pub request_review: PsRequestReviewConfig,
@@ -42,4 +44,10 @@ pub struct PsListConfig {
     pub extra_patch_info_length: usize,
     pub reverse_order: bool,
     pub alternate_colors: bool,
+    pub patch_series_background: ColorWithAlternate,
+    pub patch_series_foreground: ColorWithAlternate,
+    pub patch_series_index: ColorWithAlternate,
+    pub patch_series_sha: ColorWithAlternate,
+    pub patch_series_summary: ColorWithAlternate,
+    pub patch_series_extra_patch_info: ColorWithAlternate,
 }

--- a/src/ps/private/config/ps_config.rs
+++ b/src/ps/private/config/ps_config.rs
@@ -41,4 +41,5 @@ pub struct PsListConfig {
     pub add_extra_patch_info: bool,
     pub extra_patch_info_length: usize,
     pub reverse_order: bool,
+    pub alternate_colors: bool,
 }

--- a/src/ps/public/list.rs
+++ b/src/ps/public/list.rs
@@ -68,14 +68,9 @@ fn bg_color(
 ) -> Option<ansi_term::Colour> {
     let super_light_gray = Fixed(237);
 
-    if alternate_colors {
-        if (is_connected_to_prev_row && prev_row_showed_color)
-            || (!is_connected_to_prev_row && !prev_row_showed_color)
-        {
-            Some(super_light_gray)
-        } else {
-            None
-        }
+    if alternate_colors && is_connected_to_prev_row == prev_row_showed_color
+    {
+        Some(super_light_gray)
     } else {
         None
     }

--- a/src/ps/public/list.rs
+++ b/src/ps/public/list.rs
@@ -64,13 +64,18 @@ impl std::error::Error for ListError {
 fn bg_color(
     is_connected_to_prev_row: bool,
     prev_row_showed_color: bool,
+    alternate_colors: bool,
 ) -> Option<ansi_term::Colour> {
     let super_light_gray = Fixed(237);
 
-    if (is_connected_to_prev_row && prev_row_showed_color)
-        || (!is_connected_to_prev_row && !prev_row_showed_color)
-    {
-        Some(super_light_gray)
+    if alternate_colors {
+        if (is_connected_to_prev_row && prev_row_showed_color)
+            || (!is_connected_to_prev_row && !prev_row_showed_color)
+        {
+            Some(super_light_gray)
+        } else {
+            None
+        }
     } else {
         None
     }
@@ -339,7 +344,7 @@ pub fn list(color: bool) -> Result<(), ListError> {
             prev_patch_branches = vec![];
         }
 
-        let bg_color = bg_color(connected_to_prev_row, prev_row_included_bg);
+        let bg_color = bg_color(connected_to_prev_row, prev_row_included_bg, config.list.alternate_colors);
         prev_row_included_bg = bg_color.is_some();
 
         row.add_cell(Some(5), Some(Green), bg_color, format!("{} ", patch.index));

--- a/src/ps/public/list.rs
+++ b/src/ps/public/list.rs
@@ -1,12 +1,12 @@
 use super::super::super::ps;
 use super::super::private::config;
+use super::super::private::config::ColorSelector;
 use super::super::private::git;
 use super::super::private::git::RebaseTodoCommand;
 use super::super::private::list;
 use super::super::private::paths;
 use super::super::private::state_computation;
 use ansi_term::Color;
-use ansi_term::Colour::{Blue, Cyan, Fixed, Green, Yellow};
 use std::cmp::Ordering;
 
 #[derive(Debug)]
@@ -61,21 +61,6 @@ impl std::error::Error for ListError {
     }
 }
 
-fn bg_color(
-    is_connected_to_prev_row: bool,
-    prev_row_showed_color: bool,
-    alternate_colors: bool,
-) -> Option<ansi_term::Colour> {
-    let super_light_gray = Fixed(237);
-
-    if alternate_colors && is_connected_to_prev_row == prev_row_showed_color
-    {
-        Some(super_light_gray)
-    } else {
-        None
-    }
-}
-
 fn is_connected_to_prev_row(prev_patch_branches: &[String], cur_patch_branches: &[String]) -> bool {
     cur_patch_branches
         .iter()
@@ -84,7 +69,7 @@ fn is_connected_to_prev_row(prev_patch_branches: &[String], cur_patch_branches: 
         .unwrap()
 }
 
-fn rebase_todo_command_to_row(todo: &RebaseTodoCommand, color: bool) -> list::ListRow {
+fn rebase_todo_command_to_row(todo: &RebaseTodoCommand, color: bool, patch_series_index_color: Option<Color>, patch_series_sha_color: Option<Color>) -> list::ListRow {
     let mut row = list::ListRow::new(color);
     match todo {
         RebaseTodoCommand::Pick {
@@ -131,8 +116,8 @@ fn rebase_todo_command_to_row(todo: &RebaseTodoCommand, color: bool) -> list::Li
             keep_only_this_commits_message: _,
             open_editor: _,
         } => {
-            row.add_cell(Some(11), Some(Green), None, format!("{} ", key.clone()));
-            row.add_cell(Some(8), Some(Yellow), None, format!("{:.7} ", sha.clone()));
+            row.add_cell(Some(11), patch_series_index_color, None, format!("{} ", key.clone()));
+            row.add_cell(Some(8), patch_series_sha_color, None, format!("{:.7} ", sha.clone()));
             row.add_cell(Some(51), None, None, format!("{:.50} ", rest.clone()));
             row
         }
@@ -144,10 +129,10 @@ fn rebase_todo_command_to_row(todo: &RebaseTodoCommand, color: bool) -> list::Li
             oneline,
             reword: _,
         } => {
-            row.add_cell(Some(11), Some(Green), None, format!("{} ", key.clone()));
+            row.add_cell(Some(11), patch_series_index_color, None, format!("{} ", key.clone()));
             row.add_cell(
                 Some(8),
-                Some(Yellow),
+                patch_series_sha_color,
                 None,
                 format!("{:.7} ", sha.clone().unwrap_or("".to_string())),
             );
@@ -165,7 +150,7 @@ fn rebase_todo_command_to_row(todo: &RebaseTodoCommand, color: bool) -> list::Li
         | RebaseTodoCommand::Reset { line: _, key, rest }
         | RebaseTodoCommand::UpdateRef { line: _, key, rest }
         | RebaseTodoCommand::Noop { line: _, key, rest } => {
-            row.add_cell(Some(11), Some(Green), None, format!("{} ", key.clone()));
+            row.add_cell(Some(11), patch_series_index_color, None, format!("{} ", key.clone()));
             row.add_cell(Some(51), None, None, format!("{:.50} ", rest.clone()));
             row
         }
@@ -174,7 +159,7 @@ fn rebase_todo_command_to_row(todo: &RebaseTodoCommand, color: bool) -> list::Li
             key,
             message,
         } => {
-            row.add_cell(Some(11), Some(Green), None, format!("{} ", key.clone()));
+            row.add_cell(Some(11), patch_series_index_color, None, format!("{} ", key.clone()));
             row.add_cell(Some(51), None, None, format!("{:.50} ", message.clone()));
             row
         }
@@ -253,7 +238,7 @@ pub fn list(color: bool) -> Result<(), ListError> {
                 todos_vec.len()
             );
             for todo in todos_vec.iter().rev() {
-                println!("{}", rebase_todo_command_to_row(todo, color));
+                println!("{}", rebase_todo_command_to_row(todo, color, config.list.patch_series_index.select_color(false), config.list.patch_series_sha.select_color(false)));
             }
             println!("(use \"git rebase --edit-todo\" to view and edit)");
             println!("(use \"git rebase --continue\" once you are satisfied with your changes)");
@@ -339,36 +324,42 @@ pub fn list(color: bool) -> Result<(), ListError> {
             prev_patch_branches = vec![];
         }
 
-        let bg_color = bg_color(connected_to_prev_row, prev_row_included_bg, config.list.alternate_colors);
+        let is_alternate = config.list.alternate_colors && connected_to_prev_row == prev_row_included_bg ;
+        let bg_color = config.list.patch_series_background.select_color(is_alternate);
         prev_row_included_bg = bg_color.is_some();
-
-        row.add_cell(Some(5), Some(Green), bg_color, format!("{} ", patch.index));
+        let fg_color = config.list.patch_series_foreground.select_color(is_alternate);
+        let sha_color = config.list.patch_series_sha.select_color(is_alternate);
+        let index_color = config.list.patch_series_index.select_color(is_alternate); 
+        let summary_color = config.list.patch_series_summary.select_color(is_alternate);
+        let extra_patch_info_color = config.list.patch_series_extra_patch_info.select_color(is_alternate);
+        
+        row.add_cell(Some(5), sha_color, bg_color, format!("{} ", patch.index));
         row.add_cell(
             Some(8),
-            Some(Yellow),
+            index_color,
             bg_color,
             format!("{:.7} ", patch.oid),
         );
         row.add_cell(
             Some(51),
-            None,
+            fg_color,
             bg_color,
             format!("{:.50} ", patch.summary.clone()),
         );
 
         if let Some(ps_id) = ps::commit_ps_id(&commit) {
             if let Some(patch_info) = patch_info_collection.get(&ps_id) {
-                row.add_cell(Some(2), Some(Cyan), bg_color, "( ");
+                row.add_cell(Some(2), summary_color, bg_color, "( ");
                 for b in patch_info.branches.iter() {
                     match patch_info.branches.len().cmp(&1) {
                         Ordering::Greater => {
-                            row.add_cell(None, None, bg_color, format!("{} ", b.name.clone()));
+                            row.add_cell(None, fg_color, bg_color, format!("{} ", b.name.clone()));
                         }
                         Ordering::Less => {}
                         Ordering::Equal => {
                             let branch_info = patch_info.branches.first().unwrap();
                             if !branch_info.name.starts_with("ps/rr/") {
-                                row.add_cell(None, None, bg_color, format!("{} ", b.name.clone()));
+                                row.add_cell(None, fg_color, bg_color, format!("{} ", b.name.clone()));
                             }
                         }
                     }
@@ -431,7 +422,7 @@ pub fn list(color: bool) -> Result<(), ListError> {
                             state_string.push('!');
                         }
                     }
-                    row.add_cell(None, Some(Blue), bg_color, format!("{} ", &state_string));
+                    row.add_cell(None, extra_patch_info_color, bg_color, format!("{} ", &state_string));
 
                     if config.list.add_extra_patch_info {
                         let hook_stdout = list::execute_list_additional_info_hook(
@@ -448,18 +439,18 @@ pub fn list(color: bool) -> Result<(), ListError> {
                         let hook_stdout_len = config.list.extra_patch_info_length;
                         row.add_cell(
                             Some(hook_stdout_len + 1),
-                            Some(Blue),
+                            extra_patch_info_color,
                             bg_color,
                             format!("{} ", hook_stdout),
                         );
                     }
                 }
-                row.add_cell(Some(2), Some(Cyan), bg_color, ")");
+                row.add_cell(Some(2), summary_color, bg_color, ")");
             } else {
-                row.add_cell(None, Some(Cyan), bg_color, "()")
+                row.add_cell(None, summary_color, bg_color, "()")
             }
         } else {
-            row.add_cell(None, Some(Cyan), bg_color, "()")
+            row.add_cell(None, summary_color, bg_color, "()")
         }
 
         println!("{}", row);
@@ -473,7 +464,7 @@ pub fn list(color: bool) -> Result<(), ListError> {
             todos_vec.len()
         );
         for todo in todos_vec.iter() {
-            println!("{}", rebase_todo_command_to_row(todo, color));
+            println!("{}", rebase_todo_command_to_row(todo, color, config.list.patch_series_index.select_color(false), config.list.patch_series_sha.select_color(false)));
         }
         println!("(use \"git rebase --edit-todo\" to view and edit)");
         println!("(use \"git rebase --continue\" once you are satisfied with your changes)");


### PR DESCRIPTION
Here is configuration support for the colors in `gps list`.

We are using the builtin decoders for ansi_term which means we can do things like:

```
[list]
alternate_colors = true 
patch_series_background.color = "Blue"
patch_series_background.color_alternate = "Green"
patch_series_foreground.color.RGB = [195, 234, 222]
patch_series_foreground.color_alternate.RGB = [235, 23, 55]
```

leading to:

![image](https://github.com/uptech/git-ps-rs/assets/8614547/821a2cd2-2475-40c0-9116-d279548e15e4)

As you can see, it is a bit buggy as I think I've messed up the alternating coloring for the patch stacks. In this example, there should be 3 green patches rather than 2.

@drewdeponte hopefully you can build on this.